### PR TITLE
Revamp CLAUDE.md, refrresh README.md, add AI skills

### DIFF
--- a/.agents/skills/configuring-netop-platform
+++ b/.agents/skills/configuring-netop-platform
@@ -1,0 +1,1 @@
+../../skills/configuring-netop-platform

--- a/.agents/skills/deploying-network-operator
+++ b/.agents/skills/deploying-network-operator
@@ -1,0 +1,1 @@
+../../skills/deploying-network-operator

--- a/.agents/skills/managing-netop-devices
+++ b/.agents/skills/managing-netop-devices
@@ -1,0 +1,1 @@
+../../skills/managing-netop-devices

--- a/.agents/skills/testing-netop-configs
+++ b/.agents/skills/testing-netop-configs
@@ -1,0 +1,1 @@
+../../skills/testing-netop-configs

--- a/.agents/skills/troubleshooting-network-operator
+++ b/.agents/skills/troubleshooting-network-operator
@@ -1,0 +1,1 @@
+../../skills/troubleshooting-network-operator

--- a/.agents/skills/upgrading-network-operator
+++ b/.agents/skills/upgrading-network-operator
@@ -1,0 +1,1 @@
+../../skills/upgrading-network-operator

--- a/.claude/skills/configuring-netop-platform
+++ b/.claude/skills/configuring-netop-platform
@@ -1,0 +1,1 @@
+../../skills/configuring-netop-platform

--- a/.claude/skills/deploying-network-operator
+++ b/.claude/skills/deploying-network-operator
@@ -1,0 +1,1 @@
+../../skills/deploying-network-operator

--- a/.claude/skills/managing-netop-devices
+++ b/.claude/skills/managing-netop-devices
@@ -1,0 +1,1 @@
+../../skills/managing-netop-devices

--- a/.claude/skills/testing-netop-configs
+++ b/.claude/skills/testing-netop-configs
@@ -1,0 +1,1 @@
+../../skills/testing-netop-configs

--- a/.claude/skills/troubleshooting-network-operator
+++ b/.claude/skills/troubleshooting-network-operator
@@ -1,0 +1,1 @@
+../../skills/troubleshooting-network-operator

--- a/.claude/skills/upgrading-network-operator
+++ b/.claude/skills/upgrading-network-operator
@@ -1,0 +1,1 @@
+../../skills/upgrading-network-operator

--- a/.cursor/skills/configuring-netop-platform
+++ b/.cursor/skills/configuring-netop-platform
@@ -1,0 +1,1 @@
+../../skills/configuring-netop-platform

--- a/.cursor/skills/deploying-network-operator
+++ b/.cursor/skills/deploying-network-operator
@@ -1,0 +1,1 @@
+../../skills/deploying-network-operator

--- a/.cursor/skills/managing-netop-devices
+++ b/.cursor/skills/managing-netop-devices
@@ -1,0 +1,1 @@
+../../skills/managing-netop-devices

--- a/.cursor/skills/testing-netop-configs
+++ b/.cursor/skills/testing-netop-configs
@@ -1,0 +1,1 @@
+../../skills/testing-netop-configs

--- a/.cursor/skills/troubleshooting-network-operator
+++ b/.cursor/skills/troubleshooting-network-operator
@@ -1,0 +1,1 @@
+../../skills/troubleshooting-network-operator

--- a/.cursor/skills/upgrading-network-operator
+++ b/.cursor/skills/upgrading-network-operator
@@ -1,0 +1,1 @@
+../../skills/upgrading-network-operator

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,122 +6,102 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **netop-tools** automates deployment and management of NVIDIA Network Operator in Kubernetes clusters. It handles RDMA networking, SR-IOV Virtual Functions (VFs), IPoIB, Macvlan, and HostDev network configurations for AI/ML workloads on bare metal and virtualized Kubernetes environments.
 
-The tooling is undergoing a migration from Bash scripts (legacy, 228+ scripts) to a unified Python CLI (`python_tools/`).
+The codebase is ~250 Bash scripts organized by function.
 
 ## Setup
 
 ```bash
-# Set the required environment variable
-source NETOP_ROOT_DIR.sh
-
-# Copy and customize platform config
-cp config/{platform}/global_ops_user.cfg global_ops_user.cfg
-# Edit global_ops_user.cfg for your environment
-
-# Load full configuration
-source global_ops.cfg
+source NETOP_ROOT_DIR.sh                    # exports NETOP_ROOT_DIR=$(pwd)
+cp config/{platform}/global_ops_user.cfg.{variant} global_ops_user.cfg
+# edit global_ops_user.cfg for your environment
+source global_ops.cfg                       # loads all config (requires global_ops_user.cfg)
+./setuc.sh [usecase]                        # creates uc/ symlink → usecase/{USECASE}/
 ```
 
 ## Testing
 
+Tests use YAML diff validation — scripts generate config with `CREATE_CONFIG_ONLY=1` and compare against baseline YAML files in `tests/{usecase}/`.
+
 ```bash
-# Unit tests only (safe, no infrastructure required)
-./run_tests.sh unit
+# Run all tests (requires NETOP_ROOT_DIR to be set)
+source NETOP_ROOT_DIR.sh
+./tests/unitest.sh
 
-# Test a specific command
-./run_tests.sh command subnet
-
-# Quick validation
-./run_tests.sh quick
-
-# Full integration tests (requires K8s cluster + hardware)
-./run_tests.sh integration
-
-# Direct Python test file
-python3 test_netop_tools.py
+# Run a single test by passing its config file path
+./tests/unitest.sh tests/sriovnet_rdma/config
 ```
 
-GitHub Actions (`.github/workflows/main.yml`) runs tests on every push against ubuntu-22.04.
+CI (`.github/workflows/main.yml`) runs `tests/unitest.sh` on ubuntu-22.04 on every push.
+
+**Adding tests**: Create a directory under `tests/` with a `config` file (sourced as `GLOBAL_OPS_USER`), optional `netop.cfg` overrides, and `*.yaml` baseline files. The test harness discovers test directories by finding `config` files via `find`.
 
 ## Architecture
 
-### Configuration System
+### Configuration Cascade
 
-The configuration system is the foundation of the entire toolset:
+**Priority**: ENV vars > `global_ops_user.cfg` > `usecase/{USECASE}/netop.cfg` > defaults in `global_ops.cfg`
 
-- `global_ops.cfg` — master config with 250+ variables (K8s, network, hardware, operator versions). Sources `global_ops_user.cfg` and use-case-specific `netop.cfg`.
-- `global_ops_user.cfg` — user/platform overrides (not committed per platform)
-- `config/{platform}/global_ops_user.cfg.*` — pre-built platform configs (dgx, dell, lenovo, oci, pdx, smc)
-- `usecase/{usecase}/netop.cfg` — use-case-specific overrides
+- `global_ops.cfg` — master config (~250 lines). Sources `global_ops_user.cfg` first, then `usecase/${USECASE}/netop.cfg` at the end. Exports 40+ variables controlling K8s version, operator version, IPAM, VF counts, feature gates, etc.
+- `global_ops_user.cfg` — platform/user overrides (not committed). Copy from `config/{platform}/` variants.
+- `usecase/{usecase}/netop.cfg` — use-case-specific overrides (device lists, network files, etc.)
 
-**Priority**: ENV vars > user config > use-case config > defaults in `global_ops.cfg`
+`NETOP_ROOT_DIR` must be set before sourcing any config. The `CREATE_CONFIG_ONLY` variable (default `"1"`) controls whether scripts actually execute `helm`/`kubectl` commands or just echo them — this is how the test harness works.
 
-`NETOP_ROOT_DIR` must be set before sourcing any config.
+### Deployment Pipeline
 
-### Python Tools (`python_tools/`)
+```
+ins-network-operator.sh
+  ├─ setuc.sh                    → validate + create uc/ symlink
+  ├─ mksecret.sh                 → image pull secret
+  ├─ ops/mk-config.sh            → orchestrates all config generation:
+  │   ├─ ops/mk-values.sh        → Helm values.yaml (feature flags, images)
+  │   ├─ ops/mk-nic-cluster-policy.sh → NicClusterPolicy CRD
+  │   ├─ ops/mk-network-cr.sh    → SriovNetwork + NetworkAttachmentDefinition
+  │   ├─ ops/mk-ipam-cr.sh       → IPPool or CIDRPool
+  │   ├─ ops/mk-sriov-node-pool.sh → SR-IOV VF allocation policy
+  │   └─ ops/mk-nic-config.sh    → NIC firmware config (if NIC_CONFIG_ENABLE=true)
+  ├─ helm install network-operator
+  └─ ops/apply-network-cr.sh     → kubectl apply all generated CRDs
+```
 
-Unified CLI replacing the legacy bash scripts:
+### Key Conventions
 
-- `netop_tools.py` — main entry point, argparse setup, command dispatch
-- `config.py` — `NetOpConfig` dataclass + config loading from shell-sourced variables
-- `utils.py` — shared subprocess helpers, logging
-- `subnet_generator.py` — IP subnet generation for IPAM
-- `device_tools.py` — SR-IOV VF configuration, PCI device management
-- `k8s_tools.py` — kubectl/helm operations, K8s resource management
-- `must_gather.py` — diagnostic collection from K8s cluster
-- `commands/` — hierarchical command implementations (ops, install, uninstall, arp, harbor, etc.)
+- **Use-case symlink**: `./setuc.sh` creates `uc/` → `usecase/${USECASE}/`. Scripts reference `${USECASE_DIR}` or `./uc/` interchangeably. Generated YAML files land in the use-case directory.
+- **Device list format**: `NETOP_NETLIST=( a,,,0000:08:00.0 b,,,0000:86:00.1 )` — tuple of `device_index,reserved,reserved,pci_bdf`. Separate IPPool/SriovNetwork CRDs are generated per device.
+- **Combined mode**: When `NETOP_BCM_CONFIG=true`, multiple network definitions are merged into single `combined-*.yaml` files instead of separate per-device files.
+- **Subnet generation**: `ops/generate_subnets.sh` splits `NETOP_NETWORK_RANGE` into per-node blocks of `NETOP_PERNODE_BLOCKSIZE` (default 32) IPs.
 
-### Legacy Bash Scripts
+### Directory Layout
 
-Organized by function:
-- `ops/` — network operations, resource generation (mk-network-cr.sh, mk-values.sh, apply-network-cr.sh)
-- `install/` — K8s and component installation
-- `uninstall/` — cleanup scripts
-- `arptools/`, `rdmatest/`, `harbor/`, `repotools/` — specialized tools
+| Directory | Purpose |
+|---|---|
+| `ops/` | Core operations: config generation (`mk-*.sh`), CR management, device tools (~110 scripts) |
+| `install/` | K8s cluster bootstrap, platform-specific installers (`ubuntu/`, `rhel/`) |
+| `uninstall/` | Cleanup/removal scripts |
+| `config/{platform}/` | Pre-built platform configs: bcm11, dell, dgx, examples, igx, kvm, lenovo, oci, pdx, smc |
+| `usecase/{name}/` | Use-case definitions with `netop.cfg` and generated YAML output |
+| `tests/` | Test configs + baseline YAML files |
+| `release/` | Versioned Helm chart configurations (controlled by `NETOP_VERSION`, default `26.1.0`) |
 
 ### Use Cases
 
-Each use case directory (`usecase/{name}/`) contains network definitions, IP pool configs, and app templates:
-
-| Use Case | Description |
-|---|---|
-| `sriovnet_rdma` | SR-IOV with RDMA (most common) |
-| `sriovibnet_rdma` | SR-IOV InfiniBand with RDMA |
-| `hostdev_rdma_sriov` | HostDevice with SR-IOV |
-| `ipoib_rdma_shared_device` | IPoIB with shared device |
-| `macvlan_rdma_shared_device` | Macvlan with shared RDMA |
-
-### Network CR Generation Workflow
-
-```
-global_ops.cfg + global_ops_user.cfg
-    ↓
-ops/mk-network-cr.sh
-    ├─ mk-nic-cluster-policy.sh  → NicClusterPolicy CRD
-    ├─ mk-sriovnet-node-policy.sh → SriovNetworkNodePolicy
-    ├─ mk-network-attachment.sh  → NetworkAttachmentDefinition
-    └─ mk-ipam-cr.sh             → IPPool or CIDRPool
-    ↓
-ops/mk-values.sh → Helm values (operator feature flags, image versions)
-    ↓
-helm install network-operator + kubectl apply CRDs
-```
-
-### Helm Charts
-
-`release/` contains versioned Helm chart configurations from 24.10.0 through 26.1.0. The active version is controlled by `NETOP_VERSION` in config.
+| Use Case | Description | VFs |
+|---|---|---|
+| `sriovnet_rdma` | SR-IOV with RDMA (default) | 8 |
+| `sriovibnet_rdma` | SR-IOV InfiniBand with RDMA | 8 |
+| `hostdev_rdma_sriov` | HostDevice with SR-IOV | 8 |
+| `ipoib_rdma_shared_device` | IPoIB with shared device | 0 |
+| `macvlan_rdma_shared_device` | Macvlan with shared RDMA | 0 |
 
 ### Key Configuration Variables
 
-- `NETOP_VERSION` — Network Operator helm chart version
-- `NETOP_NAMESPACE` / `NETOP_NETWORK_RANGE` — deployment namespace and CIDR
-- `NETOP_VENDOR` — PCI vendor ID (default `"15b3"` for Mellanox/NVIDIA)
-- `NUM_VFS` — number of SR-IOV virtual functions
-- `IPAM_TYPE` / `NVIPAM_POOL_TYPE` — IP address management configuration
-- `NFD_ENABLE` / `NIC_CONFIG_ENABLE` / `MAINTENANCE_OPERATOR_ENABLE` — operator feature flags
-- `K8CL` — Kubernetes cluster name / `K8SVER` — K8s version
-- `USECASE` — active use case (e.g., `sriovnet_rdma`)
-
-## Bash-to-Python Migration
-
-See `BASH_TO_PYTHON_CONVERSION.md` for mapping between legacy bash commands and their Python equivalents. When adding new functionality, prefer Python in `python_tools/commands/` and maintain backward-compatible command names.
+- `NETOP_VERSION` — Helm chart version (default `26.1.0`)
+- `NETOP_NAMESPACE` — operator namespace (default `nvidia-network-operator`)
+- `NETOP_NETWORK_RANGE` — secondary RDMA network CIDR (L2, not routed)
+- `NETOP_NETLIST` — array of PCI devices to configure
+- `USECASE` — active use case (default `sriovnet_rdma`)
+- `NUM_VFS` — SR-IOV virtual function count
+- `IPAM_TYPE` — IP management (`nv-ipam` for large clusters, `whereabouts` for <60 nodes)
+- `DEVICE_TYPES` — NIC types array (e.g., `connectx-6`, `connectx-7`)
+- `CREATE_CONFIG_ONLY` — `"1"` to generate YAML only without deploying
+- `NETOP_BCM_CONFIG` — `"true"` enables combined multi-device YAML mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,16 +6,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **netop-tools** automates deployment and management of NVIDIA Network Operator in Kubernetes clusters. It handles RDMA networking, SR-IOV Virtual Functions (VFs), IPoIB, Macvlan, and HostDev network configurations for AI/ML workloads on bare metal and virtualized Kubernetes environments.
 
-The codebase is ~250 Bash scripts organized by function.
+The codebase consists of ~250 Bash scripts organized by function, plus a Python CLI (`python_tools/`) that provides a unified interface for common operations.
 
 ## Setup
 
 ```bash
+# Bash workflow
 source NETOP_ROOT_DIR.sh                    # exports NETOP_ROOT_DIR=$(pwd)
 cp config/{platform}/global_ops_user.cfg.{variant} global_ops_user.cfg
 # edit global_ops_user.cfg for your environment
 source global_ops.cfg                       # loads all config (requires global_ops_user.cfg)
 ./setuc.sh [usecase]                        # creates uc/ symlink → usecase/{USECASE}/
+
+# Python CLI (alternative)
+python3 python_tools/netop_tools.py config show       # view loaded config
+python3 python_tools/netop_tools.py config validate   # validate environment
 ```
 
 ## Testing
@@ -46,6 +51,27 @@ CI (`.github/workflows/main.yml`) runs `tests/unitest.sh` on ubuntu-22.04 on eve
 - `usecase/{usecase}/netop.cfg` — use-case-specific overrides (device lists, network files, etc.)
 
 `NETOP_ROOT_DIR` must be set before sourcing any config. The `CREATE_CONFIG_ONLY` variable (default `"1"`) controls whether scripts actually execute `helm`/`kubectl` commands or just echo them — this is how the test harness works.
+
+### Python CLI (`python_tools/`)
+
+Unified Python CLI replacing common bash workflows. Invocation: `python3 python_tools/netop_tools.py [--verbose] [--config-file PATH] COMMAND`
+
+- `netop_tools.py` — main entry point, argparse setup, command dispatch
+- `config.py` — `NetOpConfig` dataclass, 5-stage config cascade (defaults → auto-detect → global_ops.cfg → ENV → global_ops_user.cfg), shell config parser
+- `utils.py` — `CommandResult` dataclass, `run_command()`, kubectl/helm/docker wrappers, validation helpers
+- `k8s_tools.py` — K8s operations (setup_usecase, install_k8s_master, cluster_status)
+- `must_gather.py` — `NetworkOperatorMustGather` class, artifact collection into timestamped directory
+
+**Implemented commands** (`commands/`):
+- `ops_commands.py` — `ops network {status|apply|delete}`, `ops config values`, `ops node {label|annotate|cordon|uncordon}`, `ops device {set-vfs|get-vfs}`, `ops check {ipam|sriov}`
+- `install_commands.py` — `install {helm|network-operator|chart|calico|crds}`, `install wait {k8s|calico}`
+- `uninstall_commands.py` — `uninstall {network-operator|calico|evicted-pods|secret}`
+
+**Legacy commands** (backward-compatible): `subnet`, `setvfs`, `finddev`, `setuc`, `ins-k8`, `start-k8`, `must-gather`, `config {show|validate|export}`
+
+**Stub commands** (not yet implemented): `rdma`, `repo`, `restart`, `test`, `upgrade`
+
+Dependencies: Python 3 (stdlib only), optional PyYAML for YAML output.
 
 ### Deployment Pipeline
 
@@ -78,7 +104,8 @@ ins-network-operator.sh
 | `ops/` | Core operations: config generation (`mk-*.sh`), CR management, device tools (~110 scripts) |
 | `install/` | K8s cluster bootstrap, platform-specific installers (`ubuntu/`, `rhel/`) |
 | `uninstall/` | Cleanup/removal scripts |
-| `config/{platform}/` | Pre-built platform configs: bcm11, dell, dgx, examples, igx, kvm, lenovo, oci, pdx, smc |
+| `python_tools/` | Python CLI: unified command interface, config management, ops/install/uninstall commands |
+| `config/{platform}/` | Pre-built platform configs: bcm11, dell, dgx (B200/B300/GB200/GB300/H100/H200/Spark), examples, igx, kvm, lenovo, oci, pdx, smc |
 | `usecase/{name}/` | Use-case definitions with `netop.cfg` and generated YAML output |
 | `tests/` | Test configs + baseline YAML files |
 | `release/` | Versioned Helm chart configurations (controlled by `NETOP_VERSION`, default `26.1.0`) |
@@ -105,3 +132,4 @@ ins-network-operator.sh
 - `DEVICE_TYPES` — NIC types array (e.g., `connectx-6`, `connectx-7`)
 - `CREATE_CONFIG_ONLY` — `"1"` to generate YAML only without deploying
 - `NETOP_BCM_CONFIG` — `"true"` enables combined multi-device YAML mode
+- `OFED_BLACKLIST_MODULES_FILE` — path to OFED blacklist file (default `/host/etc/modprobe.d/blacklist-ofed-modules.conf`)

--- a/README.md
+++ b/README.md
@@ -1,50 +1,1182 @@
-**netop-tools** provides a set of **Network-Operator** configuration
-automation scripts.
+# netop-tools
 
-**netop-tools** simplifies the configuration of common Network-Operator
-use cases.
+**netop-tools** provides configuration automation for **NVIDIA Network Operator** in Kubernetes clusters. It simplifies deployment and management of RDMA networking, SR-IOV Virtual Functions (VFs), IPoIB, Macvlan, and HostDev network configurations for AI/ML workloads on bare metal and virtualized Kubernetes environments.
 
-**git clone <https://github.com/Mellanox/netop-tools.git>**
+---
 
-**cd ./netop-tools**
+## Table of Contents
 
-**git checkout master**
+- [Quick Start](#quick-start)
+- [HOW-TO Guide](#how-to-guide)
+  - [Step 1: Environment Setup](#step-1-environment-setup)
+  - [Step 2: Use Case Selection](#step-2-use-case-selection)
+  - [Step 3: Configuration](#step-3-configuration)
+  - [Step 4: K8s Cluster Bootstrap](#step-4-k8s-cluster-bootstrap)
+  - [Step 5: Network Operator Installation](#step-5-network-operator-installation)
+  - [Step 6: Network Configuration and Deployment](#step-6-network-configuration-and-deployment)
+  - [Step 7: Application Pod Deployment](#step-7-application-pod-deployment)
+  - [Step 8: Verification and Status](#step-8-verification-and-status)
+  - [Step 9: RDMA Testing](#step-9-rdma-testing)
+  - [Step 10: Device Management](#step-10-device-management)
+  - [Step 11: Node Management](#step-11-node-management)
+  - [Step 12: Diagnostics and Must-Gather](#step-12-diagnostics-and-must-gather)
+  - [Step 13: Upgrade](#step-13-upgrade)
+  - [Step 14: Restart and Recovery](#step-14-restart-and-recovery)
+  - [Step 15: Cleanup and Uninstall](#step-15-cleanup-and-uninstall)
+- [Container Registry Tools](#container-registry-tools)
+- [RDMA Debug Containers](#rdma-debug-containers)
+- [ARP Tools](#arp-tools)
+- [Testing Framework](#testing-framework)
+- [Configuration Reference](#configuration-reference)
+- [Platform Configs](#platform-configs)
+- [Directory Layout](#directory-layout)
 
-**source "NETOP\_ROOT\_DIR.sh"** \# create the NETOP\_ROOT\_DIR env
-variable.
+---
 
-The **global\_ops.cfg** file defines the shared global configuration
-values for Network-Operator.
+## Quick Start
 
-Copy a usecase config override file from
-**./config/{dgx|dell|examples}/global_ops_user.cfg{selector}** -> **global\_ops\_user.cfg** 
-Override the **global\_ops.cfg** default settings to values needed for cluster.
+For experienced users who already have a K8s cluster running:
 
-**./setuc.sh** \# set the uc symlink for the selected USECASE
+```bash
+git clone https://github.com/Mellanox/netop-tools.git
+cd netop-tools
+source NETOP_ROOT_DIR.sh
+cp config/dell/global_ops_user.cfg.Dell.Poweredge.H100.H200 global_ops_user.cfg
+# Edit global_ops_user.cfg for your environment
+export CREATE_CONFIG_ONLY=0
+./install/ins-network-operator.sh
+kubectl get pods -A
+```
 
-**cd ./uc** \# edit the netop.cfg for the use case specific
-configuration
+---
 
-**cd \${NETOP\_ROOT\_DIR}**
+## HOW-TO Guide
 
-**./ins-k8.sh** \# installs os specific K8s Network-Operator
+### Step 1: Environment Setup
 
-\# and dependencies on a bare metal control plane.
+#### 1.1 Clone and initialize
 
-**kubectl get pods --A** \# verify that the Network-Operator pods are
-ready
+```bash
+git clone https://github.com/Mellanox/netop-tools.git
+cd netop-tools
+source NETOP_ROOT_DIR.sh    # Exports NETOP_ROOT_DIR=$(pwd)
+```
 
-\# for applying the network configuration
+`NETOP_ROOT_DIR` must be set before running any other script.
 
-**cd ./uc**
+#### 1.2 Select and customize a platform config
 
-**${NETOP_ROOT_DIR}/ops/apply-network-cr.sh** \# use global\_ops.cfg (includes
-{USECASE}/netop.cfg)
+Copy a pre-built config for your hardware platform:
 
-\# to apply the use case specific network resources
+```bash
+# Example: Dell PowerEdge with H100/H200
+cp config/dell/global_ops_user.cfg.Dell.Poweredge.H100.H200 global_ops_user.cfg
 
-**${NETOP_ROOT_DIR}/ops/mk-app.sh test** \# make the sample app
+# Example: DGX B200 with BCM
+cp config/dgx/global_ops_user.cfg.DGXB200.bcm global_ops_user.cfg
 
-**${NETOP_ROOT_DIR}/ops/run-app.sh test** \# run the created pod test app
+# Example: OCI cloud
+cp config/oci/global_ops_user.cfg.oci global_ops_user.cfg
+```
 
-\# use kubectl get pods --A to check the pod status
+Edit `global_ops_user.cfg` to match your environment. Key settings to verify:
+
+- `NETOP_NETLIST` — PCI addresses or interface names of your NVIDIA NICs
+- `NUM_VFS` — number of SR-IOV virtual functions per device
+- `NETOP_NETWORK_RANGE` — CIDR for the secondary RDMA network
+- `DEVICE_TYPES` — NIC model array (e.g., `connectx-7`)
+- `CREATE_CONFIG_ONLY` — set to `0` to actually deploy (default `1` generates YAML only)
+
+#### 1.3 Load configuration
+
+```bash
+source global_ops.cfg
+```
+
+This sources `global_ops_user.cfg` first, then `usecase/${USECASE}/netop.cfg`, applying the configuration cascade:
+
+**Priority** (highest to lowest): ENV vars > `global_ops_user.cfg` > `usecase/{USECASE}/netop.cfg` > `global_ops.cfg` defaults
+
+---
+
+### Step 2: Use Case Selection
+
+#### 2.1 Available use cases
+
+| Use Case | Description | VFs | Device ID Format |
+|---|---|---|---|
+| `sriovnet_rdma` | SR-IOV Ethernet with RDMA (default) | 8 | PCI BDF: `0000:08:00.0` |
+| `sriovibnet_rdma` | SR-IOV InfiniBand with RDMA | 8 | IB interface: `ibs0f1` |
+| `hostdev_rdma_sriov` | HostDevice passthrough with SR-IOV | 8 | Multi-PCI: `0000:07:00.0,0000:08:00.0` |
+| `ipoib_rdma_shared_device` | IPoIB with shared RDMA device | 0 | IB interface: `ibs0f0` |
+| `macvlan_rdma_shared_device` | Macvlan with shared RDMA device | 0 | Ethernet interface: `ens2f0np0` |
+
+#### 2.2 Set the use case
+
+```bash
+# Set via environment variable before sourcing config
+export USECASE="sriovnet_rdma"
+source global_ops.cfg
+
+# Or switch use case at any time
+./setuc.sh sriovnet_rdma
+```
+
+`setuc.sh` creates a symlink `uc/` pointing to `usecase/${USECASE}/`. Generated YAML files are written into this directory.
+
+#### 2.3 NETOP_NETLIST format
+
+The device list is the most critical per-platform setting. Format:
+
+```
+NETOP_NETLIST=( device_index,field2,field3,device_identifier )
+```
+
+| Field | Description |
+|---|---|
+| `device_index` | Alphabetic label (`a`, `b`, `c`, ...). Becomes resource suffix: `sriov_resource_a` |
+| `field2` | Reserved (leave empty) |
+| `field3` | `HCAMAX` for shared device use cases, empty for SR-IOV |
+| `device_identifier` | PCI BDF, IB interface name, or Ethernet interface name (use-case-dependent) |
+
+Examples:
+
+```bash
+# SR-IOV Ethernet (PCI BDF addresses)
+NETOP_NETLIST=( a,,,0000:08:00.0 b,,,0000:86:00.1 )
+
+# SR-IOV InfiniBand (IB interface names)
+NETOP_NETLIST=( a,,,ibs0f1 b,,,ibs1f1 )
+
+# HostDevice (multiple PCI devices per entry)
+NETOP_NETLIST=( a,,,0000:07:00.0,0000:08:00.0 b,,,0000:09:00.0,0000:0a:00.0 )
+
+# IPoIB shared device (field3 = HCAMAX)
+NETOP_NETLIST=( a,,63,ibs0f0 b,,63,ibs0f1 )
+
+# Macvlan shared device (field3 = HCAMAX)
+NETOP_NETLIST=( a,,63,ens2f0np0 b,,63,ens3f0np0 )
+```
+
+---
+
+### Step 3: Configuration
+
+#### 3.1 Feature flags
+
+| Variable | Default | Description |
+|---|---|---|
+| `OFED_ENABLE` | `true` | Deploy containerized DOCA OFED driver. Set `false` if using kernel OFED. |
+| `NFD_ENABLE` | `true` | Node Feature Discovery. Disable if GPU-operator already runs NFD. |
+| `NIC_CONFIG_ENABLE` | `false` | NIC Configuration Operator for firmware parameter tuning. |
+| `MAINTENANCE_OPERATOR_ENABLE` | `true` | Maintenance Operator for node maintenance windows. |
+| `NIC_FD_ENABLE` | `false` | NIC Feature Discovery. |
+| `ENABLE_NFSRDMA` | `false` | NFS over RDMA support. |
+| `FW_UPGRADE_ENABLE` | `false` | Firmware upgrade orchestration. |
+| `RDMASHAREDMODE` | `true` | `true`: all RDMA devices visible in pod. `false`: only allocated devices. |
+| `SBRMODE` | `false` | Source-Based Routing for E/W RDMA traffic. |
+
+#### 3.2 SR-IOV feature gates
+
+| Variable | Default | Description |
+|---|---|---|
+| `FG_PARALLEL_NIC_CONFIG` | `true` | Parallelize NIC configuration (faster). |
+| `FG_RESOURCE_INJECTOR_MATCH` | `false` | Match condition for resource injection. |
+| `FG_MLNX_FW_RESET` | `false` | Mellanox firmware reset capability. |
+| `METRICS_EXPORTER` | `false` | Prometheus metrics exporter. |
+| `MANAGE_SW_BRIDGE` | `false` | Manage software bridges. |
+
+#### 3.3 IPAM options
+
+| Type | Variable Setting | Best For | Description |
+|---|---|---|---|
+| **nv-ipam** | `IPAM_TYPE="nv-ipam"` | Large clusters (>60 nodes) | NVIDIA native IPAM. Supports `IPPool` and `CIDRPool` types via `NVIPAM_POOL_TYPE`. |
+| **whereabouts** | `IPAM_TYPE="whereabouts"` | Small clusters (<60 nodes) | Community CNI IPAM. Uses Kubernetes ConfigMaps. |
+| **dhcp** | `IPAM_TYPE="dhcp"` | External DHCP server | Delegates IP allocation to external DHCP daemon. |
+
+For nv-ipam, choose pool type:
+
+```bash
+export NVIPAM_POOL_TYPE="IPPool"    # Per-node IP blocks (default)
+export NVIPAM_POOL_TYPE="CIDRPool"  # Per-node CIDR subnets
+```
+
+#### 3.4 Combined mode (BCM)
+
+For multi-device platforms (e.g., DGX with 8 NICs), combined mode merges per-device YAML files into single files:
+
+```bash
+export NETOP_BCM_CONFIG="true"
+```
+
+| Standard Mode | Combined Mode |
+|---|---|
+| `network.yaml` | `combined-sriovnet.yaml` |
+| `ippool.yaml` | `combined-ippools.yaml` |
+| `node-policy.yaml` | `combined-node-policy.yaml` |
+| `values.yaml` | `netop-values.yaml` |
+
+Combined mode also disables `resourceInjectorMatchCondition`, `metricsExporter`, and `manageSoftwareBridges` feature gates.
+
+#### 3.5 Scalable units (multi-tenant)
+
+Scalable units allow separate IP pools and network definitions for different pod groups:
+
+```bash
+# Single tenant (default)
+NETOP_SULIST=( "su-1" )
+
+# Multi-tenant
+NETOP_SULIST=( "su-runai" "su-ml" "su-inference" )
+```
+
+Each SU generates its own IPPool and network CRDs per device. Resource naming pattern: `sriovnet-pool-{device}-{su}`.
+
+---
+
+### Step 4: K8s Cluster Bootstrap
+
+Skip this step if you already have a running Kubernetes cluster.
+
+#### 4.1 Full master node setup
+
+```bash
+# One-command installation (installs master, init, calico)
+./ins-k8.sh
+```
+
+Or step by step using `install/ins-k8master.sh`:
+
+```bash
+# Install K8s master components (Helm, K8s packages, Docker/containerd)
+./install/ins-k8master.sh master
+
+# Initialize cluster with kubeadm
+./install/ins-k8master.sh init
+
+# Install Calico CNI
+./install/ins-k8master.sh calico
+```
+
+Alternative one-shot script:
+
+```bash
+./startk8master.sh
+```
+
+#### 4.2 Join worker nodes
+
+On each worker node:
+
+```bash
+source NETOP_ROOT_DIR.sh
+source global_ops.cfg
+./install/ins-k8worker.sh
+```
+
+Label and configure workers from the master:
+
+```bash
+./install/ins-k8master.sh worker <NODENAME>
+```
+
+#### 4.3 Platform-specific installers
+
+Ubuntu:
+
+```bash
+./install/ubuntu/ins-k8base.sh     # K8s prerequisites (containerd, kubeadm, kubelet, kubectl)
+./install/ubuntu/ins-k8repo.sh     # Add Kubernetes APT repository
+./install/ubuntu/ins-docker.sh     # Docker CE installation
+./install/ubuntu/ins-go.sh         # Go language
+./install/ubuntu/ins-kubectx.sh    # kubectx/kubens utilities
+```
+
+RHEL/CentOS:
+
+```bash
+./install/rhel/ins-k8base.sh       # K8s prerequisites (kubeadm, kubelet, kubectl)
+./install/rhel/ins-docker.sh       # Docker installation
+./install/rhel/ins-go.sh           # Go language
+```
+
+#### 4.4 Component installers
+
+```bash
+./install/ins-helm.sh              # Helm package manager
+./install/ins-helm-repo.sh         # Add NVIDIA Helm repository
+./install/ins-calico.sh            # Calico CNI
+./install/ins-calicoctl.sh         # Calico CLI tools
+./install/ins-multus.sh            # Multus meta-plugin (secondary networks)
+./install/ins-metrics.sh           # Prometheus metrics
+./install/ins-nerdctl.sh           # nerdctl (containerd CLI)
+```
+
+#### 4.5 Verify cluster readiness
+
+```bash
+kubectl get nodes
+./install/wait-k8sready.sh         # Polls until cluster is ready
+./install/readytest.sh             # Readiness validation
+```
+
+---
+
+### Step 5: Network Operator Installation
+
+#### 5.1 Install the Network Operator
+
+```bash
+./install/ins-network-operator.sh
+```
+
+This orchestrates the full deployment pipeline:
+
+```
+ins-network-operator.sh
+  ├─ setuc.sh                      → Validate + create uc/ symlink
+  ├─ install/mksecret.sh           → Image pull secret (NGC credentials)
+  ├─ ops/mk-config.sh              → Generate all YAML config:
+  │   ├─ ops/mk-values.sh          → Helm values.yaml
+  │   ├─ ops/mk-nic-cluster-policy.sh → NicClusterPolicy CRD
+  │   ├─ ops/mk-network-cr.sh      → Network + IPAM CRDs
+  │   ├─ ops/mk-sriov-node-pool.sh → SriovNetworkPoolConfig
+  │   └─ ops/mk-nic-config.sh      → NIC config (if NIC_CONFIG_ENABLE=true)
+  ├─ helm install network-operator → Deploy operator via Helm
+  ├─ install/applycrds.sh          → Apply base CRDs
+  └─ ops/apply-network-cr.sh       → Apply network resources
+```
+
+#### 5.2 Config-only mode (dry run)
+
+By default, `CREATE_CONFIG_ONLY=1` generates YAML without deploying. To actually deploy:
+
+```bash
+export CREATE_CONFIG_ONLY=0
+./install/ins-network-operator.sh
+```
+
+#### 5.3 Alternative installation methods
+
+```bash
+./install/ins-network-operator-default.sh    # Default/stable release
+./install/ins-network-operator-beta.sh       # Beta/staging release
+```
+
+---
+
+### Step 6: Network Configuration and Deployment
+
+#### 6.1 Generate all configuration
+
+```bash
+cd usecase/${USECASE}
+${NETOP_ROOT_DIR}/ops/mk-config.sh
+```
+
+`mk-config.sh` calls the following in sequence:
+
+| Script | Output | Description |
+|---|---|---|
+| `ops/mk-values.sh` | `values.yaml` | Helm values (feature flags, image versions, operator config) |
+| `ops/mk-nic-cluster-policy.sh` | `NicClusterPolicy.yaml` | NicClusterPolicy CRD (OFED, NFD, device plugins) |
+| `ops/mk-network-cr.sh` | `network.yaml` + `ippool-*.yaml` | Network + IPAM CRDs per device |
+| `ops/mk-sriov-node-pool.sh` | `sriov-node-pool-config.yaml` | SR-IOV VF allocation policy |
+| `ops/mk-nic-config.sh` | `nic-config-crd-{type}.yaml` | NIC firmware config (if enabled) |
+
+#### 6.2 Apply network resources
+
+```bash
+${NETOP_ROOT_DIR}/ops/apply-network-cr.sh
+```
+
+This applies in order:
+1. SriovNetworkNodePolicy CRDs (SR-IOV use cases)
+2. Network CRDs (SriovNetwork, SriovIBNetwork, HostDeviceNetwork, etc.)
+3. IPAM CRDs (IPPool or CIDRPool)
+
+#### 6.3 Delete network resources
+
+```bash
+${NETOP_ROOT_DIR}/ops/delete-network-cr.sh
+```
+
+Removes all network CRDs in reverse order.
+
+#### 6.4 Subnet generation utility
+
+```bash
+# Generate subnets from a CIDR range
+./ops/generate_subnets.sh <IP/netmask> <count> [gateway_pattern]
+
+# Examples:
+./ops/generate_subnets.sh 192.170.0.0/24 3
+# Output: 192.170.0.0/24 Gateway: 192.170.0.1
+#         192.170.1.0/24 Gateway: 192.170.1.1
+#         192.170.2.0/24 Gateway: 192.170.2.1
+
+./ops/generate_subnets.sh 192.170.0.0/24 2 192.170.0.1
+# Output: 192.170.0.0/24 Gateway: 192.170.0.1
+#         192.170.1.0/24 Gateway: 192.170.1.1
+```
+
+---
+
+### Step 7: Application Pod Deployment
+
+#### 7.1 Create a test pod
+
+```bash
+# Usage: ops/mk-app.sh <podname> [num_of_pods] [app_namespace] [worker_node]
+${NETOP_ROOT_DIR}/ops/mk-app.sh test
+${NETOP_ROOT_DIR}/ops/mk-app.sh test 2                          # 2 replicas
+${NETOP_ROOT_DIR}/ops/mk-app.sh test 2 default                  # Explicit namespace
+${NETOP_ROOT_DIR}/ops/mk-app.sh test 1 default worker-node-01   # Pin to specific node
+```
+
+This generates pod YAML in `usecase/${USECASE}/apps/` with:
+- Secondary network annotations (one per device per SU)
+- GPU resource requests (if `NUM_GPUS > 0`)
+- RDMA device resource requests (per device in `NETOP_NETLIST`)
+- Privileged security context with `IPC_LOCK` capability
+
+#### 7.2 Deploy the pod
+
+```bash
+${NETOP_ROOT_DIR}/ops/run-app.sh test
+```
+
+Applies the generated YAML via `kubectl apply`.
+
+#### 7.3 Verify pod status
+
+```bash
+kubectl get pods -A
+kubectl describe pod test-1
+```
+
+---
+
+### Step 8: Verification and Status
+
+#### 8.1 Overall network status
+
+```bash
+# Comprehensive network status (attachment definitions, NicClusterPolicy, RDMA devices, IP pools)
+./ops/getnetwork.sh
+
+# Pod network attachment status
+./ops/getnetworkstatus.sh
+
+# Pod-level network details
+./ops/getpodnetworkstatus.sh
+```
+
+#### 8.2 IPAM status
+
+```bash
+# Node IPAM annotations (IP block allocations)
+./ops/checkipam.sh
+
+# IP pool usage on a specific node
+./ops/checkippool.sh <NODENAME>
+
+# List IP pools
+./ops/getippool.sh
+./ops/getippool-lst.sh
+./ops/getallocatedip.sh
+
+# CIDR pools
+./ops/getcidrpool.sh
+./ops/getcidrpools.sh
+./ops/getcidrpool-lst.sh
+```
+
+#### 8.3 SR-IOV status
+
+```bash
+# SR-IOV synchronization state
+./ops/checksriovstate.sh
+
+# Wait for SR-IOV sync to complete (can take up to 10 minutes)
+./ops/syncsriov.sh
+
+# SR-IOV node policies
+./ops/getsriovnodepolicy.sh
+
+# SR-IOV node state
+./ops/getsriovnodestate.sh
+```
+
+#### 8.4 NIC and cluster policy status
+
+```bash
+# NicClusterPolicy CRD
+./ops/getNicClusterPolicy.sh
+
+# Network attachment definitions
+./ops/get-network-attach-defs.sh
+
+# Node resources (allocatable capacity)
+./ops/get-noderesources.sh
+
+# Custom resource definitions
+./ops/getcrds.sh
+
+# All resources in a namespace
+./ops/kubectlgetall.sh [NAMESPACE]
+
+# API resources discovery
+./ops/getresource.sh <NAMESPACE>
+
+# Service endpoints
+./ops/getendpoints.sh
+```
+
+---
+
+### Step 9: RDMA Testing
+
+#### 9.1 Verify RDMA capability
+
+```bash
+# Check RDMA kernel modules are loaded
+./rdmatest/check_rdma.sh
+
+# Enumerate RDMA devices
+./rdmatest/get_rdma_dev.sh
+
+# Disable PCI ACS for peer-to-peer RDMA (run on bare metal)
+./rdmatest/disable_acs.sh
+./rdmatest/disable_acs_ext.sh    # Extended topology variant
+```
+
+#### 9.2 RDMA bandwidth tests (inside pods)
+
+RoCE (RDMA over Converged Ethernet):
+
+```bash
+# On server pod:
+./rdmatest/rocesrv.sh
+
+# On client pod:
+./rdmatest/roceclnt.sh
+```
+
+InfiniBand:
+
+```bash
+# On server pod:
+./rdmatest/rdmasrv.sh            # Starts ib_send_bw server
+
+# On client pod:
+./rdmatest/rdmaclnt.sh           # Runs ib_send_bw client
+```
+
+GPU Direct RDMA:
+
+```bash
+# On server pod:
+./rdmatest/gdrsrv.sh             # GPU Direct RDMA server
+
+# On client pod:
+./rdmatest/gdrclt.sh             # GPU Direct RDMA client
+```
+
+General InfiniBand bandwidth test:
+
+```bash
+./rdmatest/ib_bw_test.sh
+```
+
+#### 9.3 RDMA environment setup
+
+```bash
+./rdmatest/rdmasetup.sh          # Setup RDMA environment inside test pod
+./rdmatest/podports.sh           # List port bindings in test pod
+./rdmatest/podcprdma.sh          # Pod-to-pod RDMA connectivity test
+```
+
+#### 9.4 Performance testing (rdmatools/)
+
+```bash
+# Standard perftest (ib_send_bw, ib_write_bw, etc.)
+./rdmatools/perftest.sh
+
+# Perftest with CUDA GPU memory buffers
+./rdmatools/perftestcuda.sh
+./rdmatools/perftestenv.sh       # Set environment for GPU-accelerated tests
+
+# RDMA diagnostics
+./rdmatools/rdmadebug.sh
+./rdmatools/getrdmanet.sh        # List RDMA-capable network devices
+./rdmatools/show_gids            # Display InfiniBand Global IDs
+./rdmatools/k8s-netdev-mapping.sh # Map K8s pod network devices to GPU/VF allocation
+
+# RDMA traffic capture
+./rdmatools/tcpdumprdma.sh
+
+# Sysctl tuning for RDMA
+./rdmatools/sysctl_config.sh
+```
+
+---
+
+### Step 10: Device Management
+
+#### 10.1 SR-IOV virtual function (VF) configuration
+
+```bash
+# Set VFs on PCI devices (run on worker node)
+./setvfs.sh <NUM_VFS> <BDF1> [BDF2] ...
+# Example: ./setvfs.sh 8 0000:08:00.0 0000:86:00.1
+
+# Alternative VF setter
+./rundev.sh <NUM_VFS> <BDF1> [BDF2] ...
+
+# Set VFs via ops script
+./ops/setnumvfs.sh
+
+# Query current VF count
+./ops/getnumvfs.sh
+```
+
+#### 10.2 PCI device information
+
+```bash
+./ops/getpci.sh                  # List PCI devices
+./ops/getpciid.sh                # Show PCI vendor IDs
+./ops/grabpci.sh                 # Extract PCI configuration details
+./ops/pcislotparse.sh            # Parse PCI slot/BDF layout
+./ops/devlist.sh                 # List network devices
+```
+
+#### 10.3 Link speed control
+
+```bash
+# Force link speed (disables auto-negotiation)
+./ops/force_link_speed.sh <DEV> <SPEED> <XVAL>
+
+# Supported speeds: 10G, 25G, 40G, 50G, 100G, 200G, 400G, 800G
+# XVAL must match speed: 1X, 2X, 4X, 8X
+
+# Examples:
+./ops/force_link_speed.sh mlx5_0 100G 2X
+./ops/force_link_speed.sh mlx5_0 400G 4X
+
+# Check current link speed
+./ops/chklnkspeed.sh
+./ops/linkchk.sh
+```
+
+#### 10.4 Device state management
+
+```bash
+./ops/resetpcidev.sh             # Reset PCI device (unbind/rebind)
+./ops/resetdaemon.sh             # Reset container runtime daemon
+./ops/grabmofed.sh               # Download MOFED driver packages
+```
+
+#### 10.5 InfiniBand-specific
+
+```bash
+./ops/setguids.sh                # Set GUIDs for InfiniBand devices
+```
+
+---
+
+### Step 11: Node Management
+
+#### 11.1 Node labeling
+
+```bash
+./ops/labelworker.sh             # Label worker nodes with default node selector
+./ops/labelmaster.sh             # Label control plane nodes
+./ops/labelsu.sh                 # Label nodes for scalable unit (SU) assignment
+./ops/dellabelworker.sh          # Remove worker labels
+./ops/annotatenode.sh <NODENAME> # Add annotations to nodes
+```
+
+#### 11.2 Taint management
+
+```bash
+./ops/gettaints.sh               # Display all node taints
+./ops/rmtaints.sh                # Remove all NoSchedule taints
+```
+
+#### 11.3 Cordon/uncordon
+
+```bash
+# Cordon/uncordon are sourced as functions:
+source ${NETOP_ROOT_DIR}/ops/cordon.sh
+cordon                            # Cordon all worker nodes
+uncordon                          # Uncordon all worker nodes
+```
+
+#### 11.4 Control plane as worker
+
+```bash
+# Make a control plane node schedulable
+./ops/add-controlplane-as-worker.sh <NODENAME>
+
+# Restore control plane taint
+./ops/rm-controlplane-as-worker.sh <NODENAME>
+```
+
+#### 11.5 Cluster join
+
+```bash
+./ops/joincluster.sh             # Execute kubeadm join on worker nodes
+./ops/reconnectworker.sh         # Reconnect disconnected workers
+```
+
+---
+
+### Step 12: Diagnostics and Must-Gather
+
+#### 12.1 Comprehensive must-gather
+
+```bash
+./must-gather-network.sh
+```
+
+Collects all diagnostic data into `/tmp/nvidia-network-operator_YYYYMMDD_HHMM/`:
+
+| Artifact | Contents |
+|---|---|
+| `must-gather.log` | Execution log |
+| `network_operator_pod.*` | Operator pod status, YAML, and logs |
+| `daemon_pod.*` | Daemon pod logs from all nodes |
+| `network_crds.yaml` | Network CRD definitions |
+| `ippool_crds.yaml` | IP pool configurations |
+| `node_descriptions.yaml` | Node descriptions and labels |
+| `pod_network_status.yaml` | Pod network attachment status |
+| `openshift_version.yaml` | OpenShift cluster info (if applicable) |
+
+Works on both Kubernetes and OpenShift clusters.
+
+#### 12.2 Targeted diagnostics
+
+```bash
+./ops/getnetwork.sh              # Network attachment + NicClusterPolicy + RDMA + IP pools
+./ops/checkipam.sh               # IPAM node annotations
+./ops/checkippool.sh <NODENAME>  # IP pool usage on a node
+./ops/checksriovstate.sh         # SR-IOV sync status
+./ops/getNicClusterPolicy.sh     # NicClusterPolicy CRD YAML
+./ops/getfinalizers.sh           # Object finalizers (cleanup debugging)
+./ops/inspectetcd.sh             # Etcd cluster status and health
+```
+
+#### 12.3 Network testing
+
+```bash
+./ops/pingtest.sh                # Pod-to-pod connectivity test
+./ops/check-iptables.sh          # Verify iptables rules
+./ops/chkfw.sh                   # Check firewall status
+```
+
+---
+
+### Step 13: Upgrade
+
+#### 13.1 Upgrade Network Operator version
+
+```bash
+# Set new version in config
+export NETOP_VERSION="26.1.0"
+
+# Run upgrade
+./upgrade/upgrade-network-operator.sh
+```
+
+The upgrade workflow:
+1. Cordons all worker nodes
+2. Scales Network Operator deployment to 0 replicas
+3. Regenerates config for the new version (`mk-values.sh`, `mk-nic-cluster-policy.sh`, `mk-network-cr.sh`)
+4. Applies updated NicClusterPolicy and CRDs
+5. Applies updated network resources
+6. Runs `helm upgrade` with new version
+7. Uncordons worker nodes
+
+#### 13.2 Supported versions
+
+Available Helm chart versions: `24.7.0`, `24.10.0`, `24.10.1`, `25.1.0`, `25.4.0`, `25.7.0`, `25.10.0`, `26.1.0` (default)
+
+---
+
+### Step 14: Restart and Recovery
+
+#### 14.1 Restart K8s components
+
+```bash
+./restart/restartk8master.sh     # Restart control plane (etcd, kubelet)
+./restart/restartk8worker.sh     # Restart worker node (kubelet, containerd)
+./restart/removek8master.sh      # Full master cleanup (kubeadm reset, remove all K8s dirs)
+```
+
+#### 14.2 Full cluster reset
+
+```bash
+./ops/reset-cluster.sh
+```
+
+This runs `kubeadm reset`, cleans up `/etc/cni`, `/var/lib/etcd`, `/etc/kubernetes`, flushes iptables, and reinitializes the cluster.
+
+#### 14.3 Service management
+
+```bash
+./ops/stopdaemonset.sh           # Scale daemonsets to 0
+./ops/netop-replicas.sh          # Manage network operator replicas
+./ops/force_reboot.sh            # Force system reboot
+./ops/shutdown.sh                # Graceful cluster shutdown
+```
+
+---
+
+### Step 15: Cleanup and Uninstall
+
+#### 15.1 Remove Network Operator
+
+```bash
+./uninstall/unins-network-operator.sh
+```
+
+Cleanup sequence:
+1. Deletes SR-IOV, Mellanox, and node feature CRDs
+2. Deletes network attachment definitions
+3. Deletes NIC device and configuration CRDs
+4. Deletes NicClusterPolicy resources
+5. Removes Helm release
+6. Force-deletes stuck namespace
+
+#### 15.2 Component-specific cleanup
+
+```bash
+./uninstall/unins-calico.sh      # Remove Calico CNI
+./uninstall/delcrds.sh           # Delete custom resource definitions
+./uninstall/delipam.sh           # Remove IPAM resources and ConfigMaps
+./uninstall/delsecret.sh         # Remove image pull secrets
+./uninstall/delhelmchart.sh      # Uninstall Helm release
+```
+
+#### 15.3 Resource cleanup
+
+```bash
+./uninstall/delevictedpods.sh    # Remove stuck/evicted pods
+./uninstall/delstucknamespace.sh # Force-delete terminating namespaces
+./uninstall/netopcleanup.sh      # Comprehensive cleanup of all components
+```
+
+#### 15.4 Network-level cleanup
+
+```bash
+./ops/delete-network-cr.sh       # Delete all network CRDs (reverse order)
+./ops/fluship.sh                 # Flush IP addresses
+```
+
+---
+
+## Container Registry Tools
+
+### Harbor
+
+Push and pull container images to/from a Harbor registry using different container runtimes:
+
+```bash
+# Login and push
+./harbor/harborlogin.sh <image_name> [config_file]
+
+# Docker runtime
+./harbor/harbordockerpush.sh
+./harbor/harbordockerpull.sh
+
+# crictl (containerd)
+./harbor/harborcrictlpush.sh
+./harbor/harborcrictlpull.sh
+
+# ctr (containerd native)
+./harbor/harborctrpush.sh
+./harbor/harborctrpull.sh
+```
+
+Configuration in `harbor/harbor.cfg`.
+
+### NGC (NVIDIA GPU Cloud)
+
+Manage images on the NGC registry:
+
+```bash
+# Login
+./ngc/ngclogin.sh [api_key_file]
+
+# NGC CLI operations
+./ngc/ngcpullimage.sh
+./ngc/ngcpushimage.sh
+./ngc/ngc_exec.sh               # Execute commands in NGC environment
+./ngc/ngcconfigset.sh           # Set NGC config parameters
+
+# Docker operations against NGC
+./ngc/dockerpull.sh
+./ngc/dockerpushimage.sh
+./ngc/dockertagimage.sh
+
+# Remote Docker daemon
+./ngc/env_DOCKER_HOST.sh        # Set up DOCKER_HOST for remote daemon
+```
+
+Configuration in `ngc/ngc.cfg`.
+
+### Container image lifecycle
+
+```bash
+./ops/pull-release-containers.sh   # Pull all images for NETOP_VERSION
+./ops/export-release-containers.sh # Export images for offline deployment
+./ops/tag-release-containers.sh    # Tag images with release version
+./ops/changeimageonly.sh           # Update image specs in deployments
+./ops/pruneimages.sh               # Remove unused images
+```
+
+### Nerdctl
+
+```bash
+./nerdctl/nerdctl.sh             # Nerdctl wrapper
+./nerdctl/nerdctlsav.sh          # Save images to archive
+./nerdctl/nerdctlload.sh         # Load images from archive
+```
+
+---
+
+## RDMA Debug Containers
+
+Build specialized debug containers from `rdmatools/`:
+
+| Dockerfile | Purpose |
+|---|---|
+| `Dockerfile.rdmadbg` | RDMA debugging environment |
+| `Dockerfile.rdmadbg_cuda` | RDMA + CUDA debugging |
+| `Dockerfile.rping` | RPing test utility |
+| `Dockerfile.mft` | Mellanox Firmware Tools |
+| `Dockerfile.nccldbg` | NCCL collective communications debugging |
+
+```bash
+# Build debug containers
+./rdmatools/docker.build.sh
+
+# Export/import for offline use
+./rdmatools/ctrexport.sh
+./rdmatools/ctrimportimage.sh
+
+# Build NCCL from source
+./rdmatools/bldnccl.sh
+
+# Build rdma-core from source
+./rdmatools/rdma-core.sh
+
+# Install perftest with CUDA support
+./rdmatools/install_perftest_cuda.sh
+```
+
+---
+
+## ARP Tools
+
+Utilities for static ARP configuration within test pods (`arptools/`):
+
+```bash
+# Set static ARP entry between pods
+./arptools/setarp.sh <SERVER_POD> <CLIENT_POD> <NET_DEV1> [NET_DEV2] ...
+
+# Show ARP table within pods
+./arptools/getarps.sh
+
+# Flush ARP cache
+./arptools/flusharp.sh
+```
+
+---
+
+## Testing Framework
+
+Tests use YAML diff validation. Scripts generate config with `CREATE_CONFIG_ONLY=1` and compare against baseline YAML files.
+
+### Run tests
+
+```bash
+source NETOP_ROOT_DIR.sh
+
+# Run all tests
+./tests/unitest.sh
+
+# Run a specific test
+./tests/unitest.sh tests/sriovnet_rdma/1/config
+```
+
+### Test structure
+
+Each test directory under `tests/` contains:
+
+| File | Purpose |
+|---|---|
+| `config` | Sourced as `GLOBAL_OPS_USER` (platform/version overrides) |
+| `netop.cfg` | Optional use-case-specific overrides |
+| `*.yaml` | Baseline YAML files compared against generated output |
+
+### Available test scenarios
+
+| Directory | Tests |
+|---|---|
+| `tests/sriovnet_rdma/` | `1/`, `2/`, `combined/`, `rdmaMode/` |
+| `tests/sriovibnet_rdma/` | `basic/`, `combined/` |
+| `tests/hostdev/` | `basic/`, `combined/` |
+| `tests/macvlan_rdma_shared_device/` | `1/`, `combined/` |
+| `tests/25_10/` | Version 25.10 compatibility (`sriovnet_rdma/1/`, `sriovibnet_rdma/1/`) |
+
+### Adding a new test
+
+1. Create a directory under `tests/` (e.g., `tests/my_test/`)
+2. Add a `config` file with test-specific variable overrides
+3. Run `CREATE_CONFIG_ONLY=1 GLOBAL_OPS_USER=tests/my_test/config ./install/ins-network-operator.sh`
+4. Copy generated YAML from `usecase/${USECASE}/` to `tests/my_test/` as baselines
+5. The test harness discovers tests by finding `config` files via `find`
+
+CI runs `tests/unitest.sh` on ubuntu-22.04 on every push (`.github/workflows/main.yml`).
+
+---
+
+## Configuration Reference
+
+### Cluster and Kubernetes
+
+| Variable | Default | Description |
+|---|---|---|
+| `NETOP_ROOT_DIR` | (must set) | Repository root directory |
+| `K8CIDR` | `192.168.0.0/16` | Kubernetes pod CIDR |
+| `K8SVER` | `1.34` | Kubernetes version |
+| `K8CL` | `kubectl` | CLI tool (`kubectl` or `oc`) |
+| `HOST_OS` | `ubuntu` | Host OS (`ubuntu` or `rhel`) |
+| `NETOP_NAMESPACE` | `nvidia-network-operator` | Operator namespace |
+| `NETOP_APP_NAMESPACES` | `( "default" )` | Application pod namespaces |
+| `NETOP_NODESELECTOR` | `node-role.kubernetes.io/worker` | Node selector for operator |
+
+### Operator and Versions
+
+| Variable | Default | Description |
+|---|---|---|
+| `NETOP_VERSION` | `26.1.0` | Network Operator Helm chart version |
+| `PROD_VER` | `1` | `1`=production (NGC), `0`=staging |
+| `CALICO_ROOT` | `3.28.2` | Calico CNI version |
+| `CNI_PLUGINS_VERSION` | `v1.5.1` | CNI plugins version |
+| `HELM_VERSION` | `3.15.4` | Helm version |
+| `CRI_DOCKERD_VERSION` | `0.3.15` | Docker CRI version |
+
+### Network
+
+| Variable | Default | Description |
+|---|---|---|
+| `NETOP_NETWORK_RANGE` | `192.170.0.0/16` | Secondary RDMA network CIDR (L2, not routed) |
+| `NETOP_NETWORK_START` | (empty) | Optional: start of IP pool range |
+| `NETOP_NETWORK_END` | (empty) | Optional: end of IP pool range |
+| `NETOP_NETWORK_GW` | (empty) | Gateway IP for RDMA network |
+| `NETOP_NETWORK_ROUTE` | (empty) | Subnet route |
+| `NETOP_NETWORK_EXCLUDE` | (empty) | Whereabouts excluded IP list |
+| `NETOP_PERNODE_BLOCKSIZE` | `32` | IPs per node from IPAM pool |
+| `NETOP_MTU` | `1500` | MTU (`9000` for RDMA) |
+| `NETOP_VENDOR` | `15b3` | PCI vendor ID (Mellanox/NVIDIA) |
+
+### Devices and Use Cases
+
+| Variable | Default | Description |
+|---|---|---|
+| `USECASE` | `sriovnet_rdma` | Active use case |
+| `NUM_VFS` | `8` (use-case-dependent) | SR-IOV virtual function count |
+| `DEVICE_TYPES` | `( "connectx-6" )` | NIC types array |
+| `NETOP_NETLIST` | (per platform) | Device list |
+| `NETOP_SULIST` | `( "su-1" )` | Scalable unit list |
+
+### IPAM
+
+| Variable | Default | Description |
+|---|---|---|
+| `IPAM_TYPE` | `nv-ipam` | IPAM type (`nv-ipam`, `whereabouts`, `dhcp`) |
+| `NVIPAM_POOL_TYPE` | `IPPool` | Pool type (`IPPool` or `CIDRPool`) |
+
+### Output Control
+
+| Variable | Default | Description |
+|---|---|---|
+| `CREATE_CONFIG_ONLY` | `1` | `1`=generate YAML only, `0`=deploy |
+| `NETOP_BCM_CONFIG` | `false` | Combined multi-device YAML mode |
+| `NETOP_COMBINED` | `false` | Combined YAML mode |
+| `NETOP_TAG_VERSION` | `false` | Tag generated YAML with version |
+
+### SR-IOV Node Pool
+
+| Variable | Default | Description |
+|---|---|---|
+| `NETOP_SRIOV_NODE_POOL` | `1` | Max unavailable during updates (`1`, `"100%"`, or count) |
+
+### Advanced
+
+| Variable | Default | Description |
+|---|---|---|
+| `SYSCTL_CONFIG` | (empty) | Override ARP config inside test pods |
+| `NCP_NODE_AFFINITY` | `false` | Enable NicClusterPolicy node affinity |
+| `DOCA_TELEMETRY_SERVICE` | `false` | DOCA Telemetry Service |
+| `ENTRYPOINT_DEBUG` | `false` | Debug container entrypoint |
+| `DEBUG_LOG_FILE` | `/tmp/entrypoint_debug_cmds.log` | Debug log file |
+| `DEBUG_SLEEP_SEC_ON_EXIT` | `300` | Debug sleep duration on exit |
+
+---
+
+## Platform Configs
+
+Pre-built configurations in `config/`:
+
+| Platform | Directory | Key Variants |
+|---|---|---|
+| **DGX** | `config/dgx/` | DGXB200 (BCM), DGXB300, DGXGB200, DGXGB300, DGXH100, DGXH200, DGXSpark |
+| **Dell** | `config/dell/` | PowerEdge H100/H200 |
+| **Lenovo** | `config/lenovo/` | ThinkSystem SR780a/SR675 (B200) |
+| **SuperMicro** | `config/smc/` | A22GA-NBRT (B200, H200) |
+| **OCI** | `config/oci/` | Oracle Cloud Infrastructure |
+| **IGX** | `config/igx/` | NVIDIA IGX Orin RTX6000ADA |
+| **KVM** | `config/kvm/` | DGXH100 in BCM hostSRIOV VM mode |
+| **PDX** | `config/pdx/` | LENOVO H100 in BCM VM mode |
+| **BCM11** | `config/bcm11/` | BCM test configurations |
+| **Examples** | `config/examples/` | Standalone examples for each use case |
+
+Key platform differences:
+
+| Setting | Varies By |
+|---|---|
+| `DEVICE_TYPES` | NIC model per hardware (connectx-6, connectx-7, connectx-8) |
+| `NETOP_NETLIST` | PCI addresses or interface names per system |
+| `NUM_VFS` | 0, 4, 8, 12, or 16 depending on hardware/use case |
+| `OFED_ENABLE` | `true` (container DOCA) vs `false` (kernel OFED) |
+| `NIC_CONFIG_ENABLE` | `true` for platforms needing firmware tuning |
+| `NETOP_BCM_CONFIG` | `true` for BCM/multi-device platforms |
+| `MTU_DEFAULT` | `1500` (standard) vs `9000` (high-performance RDMA) |
+
+---
+
+## Directory Layout
+
+| Directory | Purpose |
+|---|---|
+| `ops/` | Core operations: config generation (`mk-*.sh`), CR management, device tools (~110 scripts) |
+| `install/` | K8s cluster bootstrap, component installers, platform-specific (`ubuntu/`, `rhel/`), bug fixes (`fixes/`) |
+| `uninstall/` | Cleanup and removal scripts |
+| `upgrade/` | Network Operator version upgrade |
+| `restart/` | K8s component restart and recovery |
+| `config/` | Pre-built platform configurations |
+| `usecase/` | Use case definitions with `netop.cfg` and generated YAML output |
+| `tests/` | Test configs and baseline YAML files |
+| `rdmatest/` | RDMA verification and bandwidth testing scripts |
+| `rdmatools/` | RDMA debug containers, performance tools, Dockerfiles |
+| `harbor/` | Harbor container registry push/pull tools |
+| `ngc/` | NGC (NVIDIA GPU Cloud) registry management |
+| `arptools/` | ARP configuration utilities |
+| `repotools/` | Git repository workflow automation |
+| `containers/` | Container image lists per operator version (CSV format) |
+| `nerdctl/` | Nerdctl (containerd CLI) wrapper scripts |
+| `release/` | Versioned Helm chart configurations |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   - [Step 13: Upgrade](#step-13-upgrade)
   - [Step 14: Restart and Recovery](#step-14-restart-and-recovery)
   - [Step 15: Cleanup and Uninstall](#step-15-cleanup-and-uninstall)
+- [Python CLI](#python-cli)
 - [Container Registry Tools](#container-registry-tools)
 - [RDMA Debug Containers](#rdma-debug-containers)
 - [ARP Tools](#arp-tools)
@@ -74,6 +75,12 @@ cp config/dell/global_ops_user.cfg.Dell.Poweredge.H100.H200 global_ops_user.cfg
 
 # Example: DGX B200 with BCM
 cp config/dgx/global_ops_user.cfg.DGXB200.bcm global_ops_user.cfg
+
+# Example: DGX GB200 (ConnectX-7, 16 VFs)
+cp config/dgx/global_ops_user.cfg.DGXGB200.bcm global_ops_user.cfg
+
+# Example: DGX GB300 (ConnectX-8, 16 VFs, NIC config enabled)
+cp config/dgx/global_ops_user.cfg.DGXGB300.bcm global_ops_user.cfg
 
 # Example: OCI cloud
 cp config/oci/global_ops_user.cfg.oci global_ops_user.cfg
@@ -356,7 +363,18 @@ export CREATE_CONFIG_ONLY=0
 ./install/ins-network-operator.sh
 ```
 
-#### 5.3 Alternative installation methods
+#### 5.3 Python CLI alternative
+
+```bash
+python3 python_tools/netop_tools.py install helm
+python3 python_tools/netop_tools.py install chart
+python3 python_tools/netop_tools.py install network-operator
+python3 python_tools/netop_tools.py install calico
+python3 python_tools/netop_tools.py install crds
+python3 python_tools/netop_tools.py install wait k8s
+```
+
+#### 5.4 Alternative installation methods
 
 ```bash
 ./install/ins-network-operator-default.sh    # Default/stable release
@@ -470,6 +488,9 @@ kubectl describe pod test-1
 
 # Pod-level network details
 ./ops/getpodnetworkstatus.sh
+
+# Python CLI alternative (JSON output)
+python3 python_tools/netop_tools.py ops network status
 ```
 
 #### 8.2 IPAM status
@@ -477,6 +498,7 @@ kubectl describe pod test-1
 ```bash
 # Node IPAM annotations (IP block allocations)
 ./ops/checkipam.sh
+# Python CLI: python3 python_tools/netop_tools.py ops check ipam
 
 # IP pool usage on a specific node
 ./ops/checkippool.sh <NODENAME>
@@ -497,6 +519,7 @@ kubectl describe pod test-1
 ```bash
 # SR-IOV synchronization state
 ./ops/checksriovstate.sh
+# Python CLI: python3 python_tools/netop_tools.py ops check sriov
 
 # Wait for SR-IOV sync to complete (can take up to 10 minutes)
 ./ops/syncsriov.sh
@@ -738,6 +761,9 @@ uncordon                          # Uncordon all worker nodes
 
 ```bash
 ./must-gather-network.sh
+
+# Python CLI alternative
+python3 python_tools/netop_tools.py must-gather --output-dir /tmp/diagnostics
 ```
 
 Collects all diagnostic data into `/tmp/nvidia-network-operator_YYYYMMDD_HHMM/`:
@@ -839,6 +865,9 @@ This runs `kubeadm reset`, cleans up `/etc/cni`, `/var/lib/etcd`, `/etc/kubernet
 
 ```bash
 ./uninstall/unins-network-operator.sh
+
+# Python CLI alternative
+python3 python_tools/netop_tools.py uninstall network-operator
 ```
 
 Cleanup sequence:
@@ -873,6 +902,51 @@ Cleanup sequence:
 ./ops/delete-network-cr.sh       # Delete all network CRDs (reverse order)
 ./ops/fluship.sh                 # Flush IP addresses
 ```
+
+---
+
+## Python CLI
+
+The `python_tools/` directory provides a unified Python CLI as an alternative to the bash scripts. It requires only Python 3 (stdlib); PyYAML is optional for YAML output.
+
+### Invocation
+
+```bash
+python3 python_tools/netop_tools.py [--verbose] [--config-file PATH] COMMAND
+```
+
+### Config management
+
+```bash
+python3 python_tools/netop_tools.py config show         # Display loaded config as JSON
+python3 python_tools/netop_tools.py config validate      # Validate environment
+python3 python_tools/netop_tools.py config export --format yaml --output config.yaml
+```
+
+### Implemented commands
+
+| Command | Subcommands | Description |
+|---|---|---|
+| `install` | `helm`, `network-operator`, `chart`, `calico`, `crds`, `wait {k8s\|calico}` | Installation operations |
+| `ops` | `network {status\|apply\|delete}`, `config values`, `node {label\|annotate\|cordon\|uncordon}`, `device {set-vfs\|get-vfs}`, `check {ipam\|sriov}` | Operational commands |
+| `uninstall` | `network-operator`, `calico`, `evicted-pods`, `secret` | Cleanup operations |
+| `must-gather` | `--output-dir DIR` | Collect diagnostics |
+| `config` | `show`, `validate`, `export` | Configuration management |
+
+### Legacy commands (backward compatible)
+
+| Command | Description |
+|---|---|
+| `subnet <CIDR> <COUNT>` | Generate IPv4 subnet sequences |
+| `setvfs <NUM> <BDF...>` | Configure SR-IOV VFs |
+| `finddev` | Find device files in netop directories |
+| `setuc [--usecase NAME]` | Setup use case symlink |
+| `ins-k8 [--stage STAGE]` | Install K8s master (stages: master, init, calico, netop, all) |
+| `start-k8` | Restart K8s master |
+
+### Stub commands (not yet implemented)
+
+`rdma`, `repo`, `restart`, `test`, `upgrade` — these exist as placeholders for future implementation.
 
 ---
 
@@ -1119,6 +1193,7 @@ CI runs `tests/unitest.sh` on ubuntu-22.04 on every push (`.github/workflows/mai
 
 | Variable | Default | Description |
 |---|---|---|
+| `OFED_BLACKLIST_MODULES_FILE` | `/host/etc/modprobe.d/blacklist-ofed-modules.conf` | Path to OFED module blacklist file |
 | `SYSCTL_CONFIG` | (empty) | Override ARP config inside test pods |
 | `NCP_NODE_AFFINITY` | `false` | Enable NicClusterPolicy node affinity |
 | `DOCA_TELEMETRY_SERVICE` | `false` | DOCA Telemetry Service |
@@ -1134,7 +1209,7 @@ Pre-built configurations in `config/`:
 
 | Platform | Directory | Key Variants |
 |---|---|---|
-| **DGX** | `config/dgx/` | DGXB200 (BCM), DGXB300, DGXGB200, DGXGB300, DGXH100, DGXH200, DGXSpark |
+| **DGX** | `config/dgx/` | DGXB200 (BCM), DGXB300 (sriovnet/macvlan), DGXGB200 (ConnectX-7), DGXGB300 (ConnectX-8), DGXH100, DGXH200, DGXSpark |
 | **Dell** | `config/dell/` | PowerEdge H100/H200 |
 | **Lenovo** | `config/lenovo/` | ThinkSystem SR780a/SR675 (B200) |
 | **SuperMicro** | `config/smc/` | A22GA-NBRT (B200, H200) |
@@ -1163,6 +1238,7 @@ Key platform differences:
 
 | Directory | Purpose |
 |---|---|
+| `python_tools/` | Python CLI: unified command interface, config management, ops/install/uninstall commands |
 | `ops/` | Core operations: config generation (`mk-*.sh`), CR management, device tools (~110 scripts) |
 | `install/` | K8s cluster bootstrap, component installers, platform-specific (`ubuntu/`, `rhel/`), bug fixes (`fixes/`) |
 | `uninstall/` | Cleanup and removal scripts |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   - [Step 13: Upgrade](#step-13-upgrade)
   - [Step 14: Restart and Recovery](#step-14-restart-and-recovery)
   - [Step 15: Cleanup and Uninstall](#step-15-cleanup-and-uninstall)
+- [AI Agent Skills](#ai-agent-skills)
 - [Python CLI](#python-cli)
 - [Container Registry Tools](#container-registry-tools)
 - [RDMA Debug Containers](#rdma-debug-containers)
@@ -905,6 +906,104 @@ Cleanup sequence:
 
 ---
 
+## AI Agent Skills
+
+netop-tools ships with reusable AI agent skills that encode operational workflows as slash commands. Skills are cross-agent portable — they work with Claude Code, Cursor, and any agent supporting the `.agents/` convention.
+
+### Architecture
+
+```
+skills/                          # SSOT (Single Source of Truth)
+  deploying-network-operator/
+    SKILL.md
+  troubleshooting-network-operator/
+    SKILL.md
+  configuring-netop-platform/
+    SKILL.md
+  managing-netop-devices/
+    SKILL.md
+  upgrading-network-operator/
+    SKILL.md
+  testing-netop-configs/
+    SKILL.md
+
+.agents/skills/  -> symlinks     # Cross-agent standard (skills.sh)
+.claude/skills/  -> symlinks     # Claude Code auto-discovery
+.cursor/skills/  -> symlinks     # Cursor auto-discovery
+```
+
+Skills are authored once in `skills/` and symlinked into each agent's directory. One file, every agent sees the same content.
+
+### Installation
+
+**Option 1: Setup script (all agents at once)**
+
+```bash
+./scripts/setup-skills.sh
+```
+
+Creates symlinks from `.agents/skills/`, `.claude/skills/`, and `.cursor/skills/` to the canonical `skills/` directory.
+
+**Option 2: Manual symlink (single agent)**
+
+```bash
+# Claude Code
+mkdir -p .claude/skills
+for s in skills/*/; do ln -sfn "../../$s" ".claude/skills/$(basename $s)"; done
+
+# Cursor
+mkdir -p .cursor/skills
+for s in skills/*/; do ln -sfn "../../$s" ".cursor/skills/$(basename $s)"; done
+
+# Cross-agent standard (.agents/)
+mkdir -p .agents/skills
+for s in skills/*/; do ln -sfn "../../$s" ".agents/skills/$(basename $s)"; done
+```
+
+**Option 3: npx skills CLI** (if using [skills.sh](https://skills.sh))
+
+```bash
+npx skills add smarunich/netop-tools --all
+```
+
+### Available Skills
+
+| Skill | Invoke | Description |
+|---|---|---|
+| **deploying-network-operator** | `/deploying-network-operator` | Full deployment pipeline: config generation, Helm install, CRD application, verification |
+| **troubleshooting-network-operator** | `/troubleshooting-network-operator` | Systematic diagnostics: must-gather, operator health, SR-IOV sync, IPAM, decision tree |
+| **configuring-netop-platform** | `/configuring-netop-platform` | Platform setup: use case selection, NETOP_NETLIST format, feature flags, IPAM options |
+| **managing-netop-devices** | `/managing-netop-devices` | Device ops: VF management, PCI tools, link speed, RDMA testing, node labeling |
+| **upgrading-network-operator** | `/upgrading-network-operator` | Version upgrade: pre-flight checks, helm upgrade, rollback, version-specific notes |
+| **testing-netop-configs** | `/testing-netop-configs` | Test framework: run tests, create baselines, debug failures, CI integration |
+
+### Writing New Skills
+
+Create a new skill directory in `skills/` with a `SKILL.md` file:
+
+```markdown
+---
+name: my-new-skill
+description: Use when [triggering conditions]. Keywords for discovery.
+---
+
+# Skill Title
+
+## Workflow
+1. Step one
+2. Step two
+```
+
+Then run `./scripts/setup-skills.sh` to symlink it into all agent directories.
+
+**Conventions**:
+- `name`: lowercase with hyphens (e.g., `deploying-network-operator`)
+- `description`: starts with "Use when...", lists triggering conditions, max 1024 chars
+- Body: concise command references, tables, common failures — under 500 words
+- No agent-specific syntax — plain markdown works everywhere
+
+---
+
 ## Python CLI
 
 The `python_tools/` directory provides a unified Python CLI as an alternative to the bash scripts. It requires only Python 3 (stdlib); PyYAML is optional for YAML output.
@@ -1238,6 +1337,7 @@ Key platform differences:
 
 | Directory | Purpose |
 |---|---|
+| `skills/` | AI agent skills (SSOT): cross-agent portable workflows for deploy, troubleshoot, configure, test |
 | `python_tools/` | Python CLI: unified command interface, config management, ops/install/uninstall commands |
 | `ops/` | Core operations: config generation (`mk-*.sh`), CR management, device tools (~110 scripts) |
 | `install/` | K8s cluster bootstrap, component installers, platform-specific (`ubuntu/`, `rhel/`), bug fixes (`fixes/`) |

--- a/scripts/setup-skills.sh
+++ b/scripts/setup-skills.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Setup AI agent skills for netop-tools
+#
+# Creates symlinks from agent-specific directories to the canonical
+# skills/ directory (SSOT). Supports Claude Code, Cursor, Continue,
+# Cline, Windsurf, and the cross-agent .agents/ standard.
+#
+# Usage:
+#   ./scripts/setup-skills.sh              # Project-level install (symlinks in repo)
+#   ./scripts/setup-skills.sh --user       # User-level install (symlinks in ~/.agents/ and ~/.<agent>/)
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_DIR="${REPO_ROOT}/skills"
+
+if [ ! -d "${SKILLS_DIR}" ]; then
+  echo "ERROR: Skills directory not found: ${SKILLS_DIR}"
+  exit 1
+fi
+
+SKILLS=$(find "${SKILLS_DIR}" -maxdepth 1 -mindepth 1 -type d -exec basename {} \;)
+SKILL_COUNT=$(echo "${SKILLS}" | wc -w)
+
+echo "Found ${SKILL_COUNT} skills in ${SKILLS_DIR}"
+
+# Determine install mode
+if [ "${1:-}" = "--user" ]; then
+  echo "Installing to user-level agent directories (~/.agents/, ~/.claude/, etc.)"
+  BASE_DIR="${HOME}"
+  # .agents is the cross-agent standard from skills.sh
+  AGENT_DIRS=".agents .claude .cursor"
+else
+  echo "Installing to project-level agent directories"
+  BASE_DIR="${REPO_ROOT}"
+  # .agents is the cross-agent standard, others are agent-specific
+  AGENT_DIRS=".agents .claude .cursor"
+fi
+
+for AGENT_DIR in ${AGENT_DIRS}; do
+  TARGET="${BASE_DIR}/${AGENT_DIR}/skills"
+  mkdir -p "${TARGET}"
+  for SKILL in ${SKILLS}; do
+    LINK="${TARGET}/${SKILL}"
+    if [ -L "${LINK}" ]; then
+      rm -f "${LINK}"
+    fi
+    if [ "${1:-}" = "--user" ]; then
+      # User-level: use absolute paths
+      ln -sfn "${SKILLS_DIR}/${SKILL}" "${LINK}"
+    else
+      # Project-level: use relative paths (portable across machines)
+      REL_PATH="../../skills/${SKILL}"
+      ln -sfn "${REL_PATH}" "${LINK}"
+    fi
+  done
+  echo "  ${AGENT_DIR}/skills/ -> ${SKILL_COUNT} symlinks"
+done
+
+echo ""
+echo "Skills installed for all agents."
+echo ""
+echo "Available skills:"
+for SKILL in ${SKILLS}; do
+  DESC=$(head -5 "${SKILLS_DIR}/${SKILL}/SKILL.md" | grep "^description:" | sed 's/^description: //')
+  printf "  %-40s %s\n" "/${SKILL}" "${DESC:0:60}"
+done

--- a/skills/configuring-netop-platform/SKILL.md
+++ b/skills/configuring-netop-platform/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: configuring-netop-platform
+description: Configure netop-tools for a specific hardware platform and use case. Use when setting up global_ops_user.cfg, choosing a use case (sriovnet_rdma, sriovibnet_rdma, hostdev, ipoib, macvlan), selecting IPAM type, configuring NETOP_NETLIST device list, setting feature flags, or switching between platforms (DGX, Dell, Lenovo, OCI, SuperMicro).
+---
+
+# Configuring netop-tools Platform
+
+Set up configuration for your hardware platform and networking use case.
+
+## Configuration Cascade
+
+**Priority** (highest to lowest): ENV vars > `global_ops_user.cfg` > `usecase/{USECASE}/netop.cfg` > `global_ops.cfg` defaults
+
+## Step 1: Copy Platform Config
+
+```bash
+source NETOP_ROOT_DIR.sh
+
+# Available platforms:
+ls config/
+# bcm11  dell  dgx  examples  igx  kvm  lenovo  oci  pdx  smc
+
+# Copy for your hardware:
+cp config/dgx/global_ops_user.cfg.DGXGB300.bcm global_ops_user.cfg
+# Edit global_ops_user.cfg
+```
+
+### Platform Quick Reference
+
+| Platform | Key Config | NIC | Typical Use Case |
+|---|---|---|---|
+| DGX B200/B300 | `config/dgx/*.bcm` | ConnectX-7/8 | `sriovibnet_rdma` or `sriovnet_rdma` |
+| DGX GB200 | `config/dgx/*.DGXGB200.bcm` | ConnectX-7, 16 VFs | `sriovibnet_rdma` |
+| DGX GB300 | `config/dgx/*.DGXGB300.bcm` | ConnectX-8, 16 VFs | `sriovibnet_rdma` |
+| DGX H100/H200 | `config/dgx/*.bcm` | ConnectX-7 | `sriovnet_rdma` |
+| Dell PowerEdge | `config/dell/*` | ConnectX-7 | `sriovnet_rdma` |
+| OCI | `config/oci/*` | ConnectX, 16 VFs | `sriovnet_rdma` |
+| Examples | `config/examples/*` | Generic | One per use case |
+
+## Step 2: Choose Use Case
+
+| Use Case | Network Type | VFs | Device Format | When to Use |
+|---|---|---|---|---|
+| `sriovnet_rdma` | SR-IOV Ethernet | 8 | PCI BDF: `0000:08:00.0` | Most common, RoCE networks |
+| `sriovibnet_rdma` | SR-IOV InfiniBand | 8 | IB interface: `ibs0f1` | InfiniBand fabrics |
+| `hostdev_rdma_sriov` | HostDevice | 8 | Multi-PCI: `0000:07:00.0,0000:08:00.0` | Exclusive device access |
+| `ipoib_rdma_shared_device` | IPoIB shared | 0 | IB: `ibs0f0` (field3=HCAMAX) | Shared IB, no VFs |
+| `macvlan_rdma_shared_device` | Macvlan shared | 0 | Eth: `ens2f0np0` (field3=HCAMAX) | Shared Ethernet, no VFs |
+
+## Step 3: Configure NETOP_NETLIST
+
+**This is the most error-prone setting.** Format: `( index,,,device_id )`
+
+```bash
+# SR-IOV Ethernet — PCI BDF addresses
+NETOP_NETLIST=( a,,,0000:08:00.0 b,,,0000:86:00.1 )
+
+# SR-IOV InfiniBand — IB interface names
+NETOP_NETLIST=( a,,,ibs0f1 b,,,ibs1f1 )
+
+# HostDevice — multiple PCI per entry
+NETOP_NETLIST=( a,,,0000:07:00.0,0000:08:00.0 )
+
+# Shared device (field3 = HCAMAX, typically 63)
+NETOP_NETLIST=( a,,63,ibs0f0 b,,63,ibs0f1 )
+```
+
+**Common mistakes**: Using PCI BDF for IB use cases, missing commas, wrong field count.
+
+## Step 4: Set Feature Flags
+
+| Variable | Default | Set When |
+|---|---|---|
+| `OFED_ENABLE` | `true` | `false` if using kernel OFED (not container) |
+| `NFD_ENABLE` | `true` | `false` if GPU-operator runs NFD |
+| `NIC_CONFIG_ENABLE` | `false` | `true` for firmware tuning (GB300, etc.) |
+| `IPAM_TYPE` | `nv-ipam` | `whereabouts` for <60 nodes, `dhcp` for external DHCP |
+| `NETOP_BCM_CONFIG` | `false` | `true` for multi-device combined YAML (DGX) |
+| `CREATE_CONFIG_ONLY` | `1` | `0` to actually deploy |
+
+## Step 5: Validate
+
+```bash
+source global_ops.cfg
+# Generate config without deploying:
+./install/ins-network-operator.sh
+# Review generated YAML:
+ls -la usecase/${USECASE}/*.yaml
+
+# Python CLI validation:
+python3 python_tools/netop_tools.py config validate
+python3 python_tools/netop_tools.py config show
+```

--- a/skills/deploying-network-operator/SKILL.md
+++ b/skills/deploying-network-operator/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: deploying-network-operator
+description: Deploy NVIDIA Network Operator to a Kubernetes cluster via netop-tools. Use when installing network operator, setting up RDMA networking, deploying SR-IOV, running ins-network-operator.sh, generating Helm values, applying network CRDs, or troubleshooting deployment failures.
+---
+
+# Deploying Network Operator
+
+Guide the full deployment pipeline from config generation through Helm install and CRD application.
+
+## Prerequisites
+
+```bash
+source NETOP_ROOT_DIR.sh
+# global_ops_user.cfg must exist and be edited for the target platform
+source global_ops.cfg
+```
+
+## Deployment Pipeline
+
+```bash
+# 1. Set use case
+./setuc.sh ${USECASE}
+
+# 2. Generate all config (dry run by default: CREATE_CONFIG_ONLY=1)
+cd usecase/${USECASE}
+${NETOP_ROOT_DIR}/ops/mk-config.sh
+
+# 3. Review generated YAML before deploying
+ls -la *.yaml
+
+# 4. Deploy (set CREATE_CONFIG_ONLY=0 to actually run helm/kubectl)
+export CREATE_CONFIG_ONLY=0
+${NETOP_ROOT_DIR}/install/ins-network-operator.sh
+```
+
+### What mk-config.sh generates
+
+| Script | Output | Purpose |
+|---|---|---|
+| `ops/mk-values.sh` | `values.yaml` | Helm values (feature flags, images) |
+| `ops/mk-nic-cluster-policy.sh` | `NicClusterPolicy.yaml` | NicClusterPolicy CRD |
+| `ops/mk-network-cr.sh` | `network.yaml` + `ippool-*.yaml` | Network + IPAM CRDs per device |
+| `ops/mk-sriov-node-pool.sh` | `sriov-node-pool-config.yaml` | SR-IOV VF allocation |
+| `ops/mk-nic-config.sh` | `nic-config-crd-{type}.yaml` | NIC firmware config (if `NIC_CONFIG_ENABLE=true`) |
+
+### Python CLI alternative
+
+```bash
+python3 python_tools/netop_tools.py install helm
+python3 python_tools/netop_tools.py install chart
+python3 python_tools/netop_tools.py install network-operator
+python3 python_tools/netop_tools.py install calico
+python3 python_tools/netop_tools.py install crds
+```
+
+## Post-Deploy Verification
+
+```bash
+kubectl get pods -n ${NETOP_NAMESPACE}
+./ops/getnetwork.sh
+./ops/checksriovstate.sh
+./ops/syncsriov.sh              # Wait for SR-IOV sync (can take 10+ min)
+./ops/checkipam.sh
+```
+
+## Common Failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| "User configuration file not found" | Missing `global_ops_user.cfg` | Copy from `config/{platform}/` |
+| Helm chart not found | Wrong `NETOP_VERSION` | Check available versions: 24.7.0 through 26.1.0 |
+| No VFs created | `CREATE_CONFIG_ONLY=1` (default) | Set `CREATE_CONFIG_ONLY=0` before deploy |
+| SR-IOV sync stuck | Normal — can take 10 min | Run `./ops/syncsriov.sh` to wait |
+| Pod network not attached | Wrong namespace | Ensure pod and network CRD are in same namespace |
+| IP pool exhausted | `NETOP_PERNODE_BLOCKSIZE` too small | Increase blocksize or `NETOP_NETWORK_RANGE` |
+
+## Key Config Variables
+
+- `CREATE_CONFIG_ONLY` — `1` (dry run) or `0` (deploy). **Default is 1.**
+- `NETOP_VERSION` — Helm chart version (default `26.1.0`)
+- `USECASE` — Use case name (default `sriovnet_rdma`)
+- `NETOP_NETLIST` — Device list (critical, format varies by use case)
+- `IPAM_TYPE` — `nv-ipam` (large clusters) or `whereabouts` (<60 nodes)

--- a/skills/managing-netop-devices/SKILL.md
+++ b/skills/managing-netop-devices/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: managing-netop-devices
+description: Manage SR-IOV virtual functions, PCI devices, link speed, and RDMA testing for NVIDIA Network Operator. Use when setting VFs, querying PCI devices, forcing link speed, running RDMA bandwidth tests, checking RDMA capability, managing node labels and taints, or cordoning nodes.
+---
+
+# Managing Network Devices and Nodes
+
+Device management, RDMA testing, and node operations for Network Operator clusters.
+
+## SR-IOV Virtual Functions
+
+```bash
+# Set VFs on PCI devices (run on worker node)
+./setvfs.sh <NUM_VFS> <BDF1> [BDF2] ...
+./setvfs.sh 8 0000:08:00.0 0000:86:00.1
+
+# Query current VF count
+./ops/getnumvfs.sh
+
+# Python CLI
+python3 python_tools/netop_tools.py ops device set-vfs 8
+python3 python_tools/netop_tools.py ops device get-vfs
+```
+
+## PCI Device Info
+
+```bash
+./ops/getpci.sh                  # List PCI devices
+./ops/getpciid.sh                # Vendor IDs (15b3 = NVIDIA/Mellanox)
+./ops/grabpci.sh                 # PCI config details
+./ops/devlist.sh                 # Network devices
+```
+
+## Link Speed
+
+```bash
+# Force link speed (disables auto-negotiation)
+./ops/force_link_speed.sh <DEV> <SPEED> <XVAL>
+# Speeds: 10G, 25G, 40G, 50G, 100G, 200G, 400G, 800G
+# XVAL: 1X, 2X, 4X, 8X (must match speed)
+./ops/force_link_speed.sh mlx5_0 400G 4X
+
+# Check current speed
+./ops/chklnkspeed.sh
+./ops/linkchk.sh
+```
+
+## RDMA Testing
+
+```bash
+# Verify RDMA capability
+./rdmatest/check_rdma.sh
+./rdmatest/get_rdma_dev.sh
+
+# Disable PCI ACS for peer-to-peer (bare metal only)
+./rdmatest/disable_acs.sh
+
+# RoCE bandwidth test (server → client)
+./rdmatest/rocesrv.sh             # On server pod
+./rdmatest/roceclnt.sh            # On client pod
+
+# InfiniBand bandwidth test
+./rdmatest/rdmasrv.sh             # Server: ib_send_bw
+./rdmatest/rdmaclnt.sh            # Client
+
+# GPU Direct RDMA
+./rdmatest/gdrsrv.sh              # Server
+./rdmatest/gdrclt.sh              # Client
+
+# Performance testing with CUDA
+./rdmatools/perftestcuda.sh
+```
+
+## Node Management
+
+```bash
+# Labeling
+./ops/labelworker.sh              # Label workers
+./ops/labelmaster.sh              # Label control plane
+./ops/labelsu.sh                  # Label for scalable units
+./ops/dellabelworker.sh           # Remove worker labels
+
+# Taints
+./ops/gettaints.sh                # Show taints
+./ops/rmtaints.sh                 # Remove NoSchedule taints
+
+# Cordon (sourced as functions)
+source ${NETOP_ROOT_DIR}/ops/cordon.sh
+cordon                             # Cordon all workers
+uncordon                           # Uncordon all workers
+
+# Python CLI
+python3 python_tools/netop_tools.py ops node cordon
+python3 python_tools/netop_tools.py ops node uncordon
+python3 python_tools/netop_tools.py ops node label rdma-capable true
+
+# Control plane as worker
+./ops/add-controlplane-as-worker.sh <NODENAME>
+./ops/rm-controlplane-as-worker.sh <NODENAME>
+```
+
+## Application Pods
+
+```bash
+# Create test pod YAML
+${NETOP_ROOT_DIR}/ops/mk-app.sh <name> [num_pods] [namespace] [worker_node]
+${NETOP_ROOT_DIR}/ops/mk-app.sh test 2 default worker-01
+
+# Deploy
+${NETOP_ROOT_DIR}/ops/run-app.sh test
+```

--- a/skills/testing-netop-configs/SKILL.md
+++ b/skills/testing-netop-configs/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: testing-netop-configs
+description: Run and create tests for netop-tools configuration generation. Use when running unitest.sh, validating YAML generation, creating new test cases, checking test baselines, debugging test failures, or verifying config changes don't break existing tests.
+---
+
+# Testing netop-tools Configurations
+
+Tests validate YAML generation by diffing output against baseline files.
+
+## Running Tests
+
+```bash
+source NETOP_ROOT_DIR.sh
+
+# Run all tests
+./tests/unitest.sh
+
+# Run a specific test
+./tests/unitest.sh tests/sriovnet_rdma/1/config
+```
+
+## How Tests Work
+
+1. Sets `CREATE_CONFIG_ONLY=1` (generate YAML, don't deploy)
+2. Sources test's `config` file as `GLOBAL_OPS_USER`
+3. Runs `install/ins-network-operator.sh` to generate YAML
+4. Runs `diff -ruN` between generated YAML and baseline `*.yaml` files
+5. Non-zero exit if any diffs found
+
+## Available Test Scenarios
+
+| Directory | Scenarios |
+|---|---|
+| `tests/sriovnet_rdma/` | `1/`, `2/`, `combined/`, `rdmaMode/` |
+| `tests/sriovibnet_rdma/` | `basic/`, `combined/` |
+| `tests/hostdev/` | `basic/`, `combined/` |
+| `tests/macvlan_rdma_shared_device/` | `1/`, `combined/` |
+| `tests/25_10/` | `sriovnet_rdma/1/`, `sriovibnet_rdma/1/` |
+
+## Creating a New Test
+
+```bash
+# 1. Create test directory
+mkdir -p tests/my_test
+
+# 2. Create config file with overrides
+cat > tests/my_test/config << 'EOF'
+export NETOP_VERSION="26.1.0"
+export USECASE="sriovnet_rdma"
+export NETOP_NETLIST=( a,,,0000:08:00.0 b,,,0000:86:00.1 )
+export DEVICE_TYPES=( "connectx-7" )
+export NUM_VFS=8
+# ... other overrides
+EOF
+
+# 3. Generate baseline YAML
+export CREATE_CONFIG_ONLY=1
+export GLOBAL_OPS_USER=$(pwd)/tests/my_test/config
+source ${GLOBAL_OPS_USER}
+${NETOP_ROOT_DIR}/install/ins-network-operator.sh
+
+# 4. Copy generated YAML as baselines
+cp usecase/${USECASE}/*.yaml tests/my_test/
+
+# 5. Verify test passes
+./tests/unitest.sh tests/my_test/config
+```
+
+## Test Directory Structure
+
+```
+tests/my_test/
+  config              # Sourced as GLOBAL_OPS_USER (required)
+  netop.cfg           # Optional use-case overrides
+  NicClusterPolicy.yaml    # Baseline YAML files
+  values.yaml
+  network.yaml
+  ippool-*.yaml
+  ...
+```
+
+## Debugging Test Failures
+
+When a test fails, `unitest.sh` shows the diff. Common causes:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| All tests fail | Changed default in `global_ops.cfg` | Regenerate all baselines |
+| One test fails | Config override missing | Add missing variable to test's `config` |
+| New YAML file not compared | Test dir missing baseline | Copy generated file to test dir |
+| Version-specific failures | `NETOP_VERSION` changed behavior | Create version-specific test under `tests/` |
+
+## CI Integration
+
+GitHub Actions (`.github/workflows/main.yml`) runs `tests/unitest.sh` on ubuntu-22.04 on every push. Tests are discovered automatically by finding `config` files via `find`.

--- a/skills/troubleshooting-network-operator/SKILL.md
+++ b/skills/troubleshooting-network-operator/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: troubleshooting-network-operator
+description: Diagnose and fix NVIDIA Network Operator issues in Kubernetes. Use when pods can't get RDMA network, SR-IOV VFs not showing, IP allocation failures, network attachment missing, must-gather diagnostics, operator pods crashing, NicClusterPolicy errors, or IPAM pool exhaustion.
+---
+
+# Troubleshooting Network Operator
+
+Systematic diagnostic flow for Network Operator issues.
+
+## Step 1: Collect Diagnostics
+
+```bash
+# Full must-gather (saves to /tmp/nvidia-network-operator_YYYYMMDD_HHMM/)
+./must-gather-network.sh
+
+# Python CLI alternative
+python3 python_tools/netop_tools.py must-gather --output-dir /tmp/diag
+```
+
+## Step 2: Check Operator Health
+
+```bash
+kubectl get pods -n ${NETOP_NAMESPACE}
+./ops/getNicClusterPolicy.sh
+./ops/getnetwork.sh
+```
+
+**What to look for**: All operator/daemon pods should be `Running`. NicClusterPolicy should show `state: ready`.
+
+## Step 3: Targeted Checks
+
+### Network not attaching to pods
+
+```bash
+./ops/get-network-attach-defs.sh   # Verify NetworkAttachmentDefinitions exist
+./ops/getnetworkstatus.sh          # Check pod network-status annotations
+./ops/getpodnetworkstatus.sh       # Pod-level details
+```
+
+### SR-IOV VFs not available
+
+```bash
+./ops/checksriovstate.sh           # Check sync status
+./ops/syncsriov.sh                 # Wait for sync (up to 10 min)
+./ops/getsriovnodepolicy.sh        # Verify node policies
+./ops/getsriovnodestate.sh         # Per-node SR-IOV state
+./ops/getnumvfs.sh                 # Query actual VF count on devices
+```
+
+### IP allocation failures
+
+```bash
+./ops/checkipam.sh                 # Node IPAM annotations
+./ops/checkippool.sh <NODENAME>    # Per-node IP usage
+./ops/getippool.sh                 # Pool definitions
+./ops/getallocatedip.sh            # Currently allocated IPs
+# Python CLI
+python3 python_tools/netop_tools.py ops check ipam
+```
+
+### Connectivity issues
+
+```bash
+./ops/pingtest.sh                  # Pod-to-pod connectivity
+./ops/check-iptables.sh            # Firewall rules
+./ops/chkfw.sh                     # Firewall status
+```
+
+## Diagnostic Decision Tree
+
+| Symptom | Check | Likely Cause |
+|---|---|---|
+| Operator pod CrashLoopBackOff | `kubectl logs -n ${NETOP_NAMESPACE} <pod>` | Version mismatch, missing CRDs |
+| No VFs on node | `checksriovstate.sh` | Sync in progress, wrong PCI BDF in `NETOP_NETLIST` |
+| Pod stuck Pending | `kubectl describe pod <pod>` | Resource not available (wrong resource name) |
+| IP not allocated | `checkipam.sh` | Pool exhausted, wrong `IPAM_TYPE`, pool not applied |
+| Network annotation missing | `getnetworkstatus.sh` | NetworkAttachmentDefinition not in pod namespace |
+| Finalizer blocking delete | `getfinalizers.sh` | Orphaned finalizer — patch to remove |
+| MTU errors | Check `NETOP_MTU` in config | Mismatch between config and physical network |
+
+## Cleanup Stuck Resources
+
+```bash
+./ops/getfinalizers.sh             # Find stuck finalizers
+./uninstall/delstucknamespace.sh   # Force-delete terminating namespaces
+./uninstall/delevictedpods.sh      # Remove evicted pods
+```
+
+## Key Log Locations in Must-Gather
+
+| File | Contents |
+|---|---|
+| `network_operator_pod.log` | Operator controller logs |
+| `network_operand_pod_*.log` | Per-daemon logs (OFED, device plugin, IPAM) |
+| `custom_resource_*.yaml` | All CRD state snapshots |
+| `nodes.yaml` | Node labels, taints, allocatable resources |

--- a/skills/upgrading-network-operator/SKILL.md
+++ b/skills/upgrading-network-operator/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: upgrading-network-operator
+description: Upgrade NVIDIA Network Operator to a new version. Use when changing NETOP_VERSION, running upgrade-network-operator.sh, migrating between operator versions, handling CRD schema changes, or rolling back a failed upgrade.
+---
+
+# Upgrading Network Operator
+
+Upgrade the Network Operator Helm release to a new version with zero-downtime node rolling.
+
+## Supported Versions
+
+`24.7.0`, `24.10.0`, `24.10.1`, `25.1.0`, `25.4.0`, `25.7.0`, `25.10.0`, `26.1.0` (default)
+
+## Pre-Upgrade Checklist
+
+1. Verify target version exists: `helm search repo nvidia/network-operator --versions`
+2. Check K8s compatibility (26.1.0 requires K8s 1.32+)
+3. Generate config for new version with `CREATE_CONFIG_ONLY=1` first
+4. Review YAML diffs between old and new generated configs
+5. Ensure all nodes are healthy: `kubectl get nodes`
+
+## Upgrade Procedure
+
+```bash
+# 1. Set new version
+export NETOP_VERSION="26.1.0"
+source global_ops.cfg
+
+# 2. Preview config changes (dry run)
+export CREATE_CONFIG_ONLY=1
+cd usecase/${USECASE}
+${NETOP_ROOT_DIR}/ops/mk-config.sh
+# Review generated YAML
+
+# 3. Run upgrade
+export CREATE_CONFIG_ONLY=0
+${NETOP_ROOT_DIR}/upgrade/upgrade-network-operator.sh
+```
+
+### What the upgrade script does
+
+1. Cordons all worker nodes
+2. Scales Network Operator deployment to 0 replicas
+3. Regenerates config: `mk-values.sh`, `mk-nic-cluster-policy.sh`, `mk-network-cr.sh`
+4. Applies updated NicClusterPolicy
+5. Applies new CRDs via `applycrds.sh`
+6. Applies network resources via `apply-network-cr.sh`
+7. Updates NIC config (if `NIC_CONFIG_ENABLE=true`)
+8. Runs `helm upgrade`
+9. Uncordons worker nodes
+
+## Post-Upgrade Verification
+
+```bash
+kubectl get pods -n ${NETOP_NAMESPACE}
+./ops/getnetwork.sh
+./ops/checksriovstate.sh
+./ops/syncsriov.sh
+./ops/checkipam.sh
+```
+
+## Version-Specific Notes
+
+| Version | Key Changes |
+|---|---|
+| 25.10.* | `MAINTENANCE_OPERATOR_ENABLE` defaults to `NIC_CONFIG_ENABLE` value |
+| 26.1.* | `MAINTENANCE_OPERATOR_ENABLE` defaults to `true` independently |
+| 25.1.0 | Uses `nicConfigurationOperator` parameter (older API) |
+| 25.4.0+ | Uses `deployNodeFeatureRules` for NFD |
+
+## Rollback
+
+If upgrade fails, restore previous config and re-run:
+
+```bash
+export NETOP_VERSION="<previous_version>"
+source global_ops.cfg
+${NETOP_ROOT_DIR}/upgrade/upgrade-network-operator.sh
+```
+
+## Common Failures
+
+| Symptom | Fix |
+|---|---|
+| Helm chart not found | Verify `NETOP_VERSION` and `helm repo update` |
+| CRD validation errors | Check feature gate compatibility with new version |
+| Nodes stuck cordoned | Run `source ops/cordon.sh && uncordon` |
+| Finalizers blocking delete | `./ops/getfinalizers.sh`, then patch to remove |


### PR DESCRIPTION
Expand and reorganize project documentation: replace the brief README with a comprehensive user and developer guide (quick start, HOW-TO, use cases, configuration reference, testing framework, deployment and upgrade procedures, RDMA/debug tools, directory layout and platform configs). Clarify setup and configuration cascade (NETOP_ROOT_DIR, global_ops_user.cfg, USECASE, NETOP_NETLIST), testing (tests/unitest.sh, YAML baseline diffing, CREATE_CONFIG_ONLY), and key variables (NETOP_VERSION, NETOP_BCM_CONFIG, NUM_VFS, IPAM_TYPE, etc.). Simplify CLAUDE.md to a concise overview with updated setup and testing instructions and a brief architecture summary. Overall documentation overhaul to aid onboarding and CI/test usage.

Add documentation for a new Python CLI (python_tools/) as an alternative to the existing bash scripts across CLAUDE.md and README.md. Includes invocation examples, implemented/legacy/stub command lists, file/module breakdown (netop_tools.py, config.py, utils.py, k8s_tools.py, must_gather.py, commands/), usage examples for install/ops/uninstall/must-gather/config commands, and dependency notes (Python 3, optional PyYAML). Also: add OFED_BLACKLIST_MODULES_FILE to documented environment variables and update DGX platform variant descriptions to include GB200/GB300 details and mark python_tools/ in the repository layout.

Introduce reusable AI agent skills and tooling: add six SKILL.md skill definitions under skills/, create agent-facing symlink entries in .agents/, .claude/, and .cursor/, add an executable scripts/setup-skills.sh to create/manage those symlinks, and update README.md with documentation and installation instructions. Skills added: deploying-network-operator, troubleshooting-network-operator, configuring-netop-platform, managing-netop-devices, upgrading-network-operator, testing-netop-configs. This wires a single source-of-truth skills/ directory into multiple agent conventions and documents how to install and author new skills.